### PR TITLE
Use 1ES-hosted agent for Ubuntu 22.04 arm64

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -26,148 +26,148 @@ variables:
 
 jobs:
 
-################################################################################
-  - job: debian_11_arm32v7
-################################################################################
-    displayName: Debian 11 arm32v7
+# ################################################################################
+#   - job: debian_11_arm32v7
+# ################################################################################
+#     displayName: Debian 11 arm32v7
 
-    pool:
-      name: $(pool.custom.name)
-      demands: deb11-e2e-tests
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: deb11-e2e-tests
 
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactName: iotedged-debian11-arm32v7
-      identityServiceArtifactName: packages_debian-11-slim_arm32v7
-      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+#     variables:
+#       os: linux
+#       arch: arm32v7
+#       artifactName: iotedged-debian11-arm32v7
+#       identityServiceArtifactName: packages_debian-11-slim_arm32v7
+#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: debian_10_arm32v7
-################################################################################
-    displayName: Debian 10 arm32v7 (minimal)
+# ################################################################################
+#   - job: debian_10_arm32v7
+# ################################################################################
+#     displayName: Debian 10 arm32v7 (minimal)
 
-    pool:
-      name: $(pool.custom.name)
-      demands: deb10-e2e-tests
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: deb10-e2e-tests
 
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactName: iotedged-debian10-arm32v7
-      identityServiceArtifactName: packages_debian-10-slim_arm32v7
-      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
-      minimal: true
+#     variables:
+#       os: linux
+#       arch: arm32v7
+#       artifactName: iotedged-debian10-arm32v7
+#       identityServiceArtifactName: packages_debian-10-slim_arm32v7
+#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+#       minimal: true
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_2004_msmoby
-################################################################################
-    displayName: Ubuntu 20.04 with iotedge-moby
+# ################################################################################
+#   - job: ubuntu_2004_msmoby
+# ################################################################################
+#     displayName: Ubuntu 20.04 with iotedge-moby
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu20.04-amd64
-      identityServiceArtifactName: packages_ubuntu-20.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu20.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-    timeoutInMinutes: 90
+#     timeoutInMinutes: 90
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_2004_docker
-################################################################################
-    displayName: Ubuntu 20.04 with Docker (minimal)
+# ################################################################################
+#   - job: ubuntu_2004_docker
+# ################################################################################
+#     displayName: Ubuntu 20.04 with Docker (minimal)
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu20.04-amd64
-      identityServiceArtifactName: packages_ubuntu-20.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      minimal: true
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu20.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#       minimal: true
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_2004_arm64v8
-################################################################################
-    displayName: Ubuntu 20.04 on arm64v8
-    pool:
-      name: $(pool.linux.arm.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
+# ################################################################################
+#   - job: ubuntu_2004_arm64v8
+# ################################################################################
+#     displayName: Ubuntu 20.04 on arm64v8
+#     pool:
+#       name: $(pool.linux.arm.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
 
-    variables:
-      os: linux
-      arch: arm64v8
-      artifactName: iotedged-ubuntu20.04-aarch64
-      identityServiceArtifactName: packages_ubuntu-20.04_aarch64
-      identityServicePackageFilter: aziot-identity-service_*_arm64.deb
+#     variables:
+#       os: linux
+#       arch: arm64v8
+#       artifactName: iotedged-ubuntu20.04-aarch64
+#       identityServiceArtifactName: packages_ubuntu-20.04_aarch64
+#       identityServicePackageFilter: aziot-identity-service_*_arm64.deb
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_2204
-################################################################################
-    displayName: Ubuntu 22.04 on amd64
+# ################################################################################
+#   - job: ubuntu_2204
+# ################################################################################
+#     displayName: Ubuntu 22.04 on amd64
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu22.04-amd64
-      identityServiceArtifactName: packages_ubuntu-22.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu22.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-22.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-    timeoutInMinutes: 90
+#     timeoutInMinutes: 90
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_2204_arm64v8
@@ -175,8 +175,9 @@ jobs:
     displayName: Ubuntu 22.04 on arm64v8
 
     pool:
-      name: $(pool.custom.name)
-      demands: ubu2204-arm64-e2e-tests
+      name: $(pool.linux.arm.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-22.04-arm64-msmoby
 
     variables:
       os: linux
@@ -193,144 +194,144 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: centos7_amd64
-################################################################################
-    displayName: CentOs7 amd64
+# ################################################################################
+#   - job: centos7_amd64
+# ################################################################################
+#     displayName: CentOs7 amd64
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-centos-7-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-centos-7-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-centos7-amd64
-      identityServiceArtifactName: packages_centos-7_amd64
-      identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-centos7-amd64
+#       identityServiceArtifactName: packages_centos-7_amd64
+#       identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
-  ################################################################################
-  - job: redhat8_amd64
-  ################################################################################
-    displayName: RedHat8 amd64
+#   ################################################################################
+#   - job: redhat8_amd64
+#   ################################################################################
+#     displayName: RedHat8 amd64
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-rhel-8-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-rhel-8-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-redhat8-amd64
-      identityServiceArtifactName: packages_redhat-ubi8-latest_amd64
-      identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-redhat8-amd64
+#       identityServiceArtifactName: packages_redhat-ubi8-latest_amd64
+#       identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
-  ################################################################################
-  - job: redhat9_amd64
-  ################################################################################
-    displayName: RedHat9 amd64
+#   ################################################################################
+#   - job: redhat9_amd64
+#   ################################################################################
+#     displayName: RedHat9 amd64
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-rhel-9-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-rhel-9-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-redhat9-amd64
-      identityServiceArtifactName: packages_redhat-ubi9-latest_amd64
-      identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-redhat9-amd64
+#       identityServiceArtifactName: packages_redhat-ubi9-latest_amd64
+#       identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: linux_amd64_proxy
-################################################################################
-    displayName: Linux amd64 behind a proxy
+# ################################################################################
+#   - job: linux_amd64_proxy
+# ################################################################################
+#     displayName: Linux amd64 behind a proxy
 
-    pool:
-      name: $(pool.custom.name)
-      demands: new-e2e-proxy
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: new-e2e-proxy
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu20.04-amd64
-      identityServiceArtifactName: packages_ubuntu-20.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
-      'agent.disablelogplugin.testfilepublisherplugin': true
-      'agent.disablelogplugin.testresultlogplugin': true
-      # because we aren't publishing test artifacts for this job, turn on verbose logging instead
-      verbose: true
-      # skip component governance detection to avoid proxy issues. It is checked in the other jobs.
-      skipComponentGovernanceDetection: true
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu20.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#       # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
+#       'agent.disablelogplugin.testfilepublisherplugin': true
+#       'agent.disablelogplugin.testresultlogplugin': true
+#       # because we aren't publishing test artifacts for this job, turn on verbose logging instead
+#       verbose: true
+#       # skip component governance detection to avoid proxy issues. It is checked in the other jobs.
+#       skipComponentGovernanceDetection: true
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
-      parameters:
-        test_type: http_proxy
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
+#       parameters:
+#         test_type: http_proxy
 
-################################################################################
-  - job: mariner2_amd64
-################################################################################
-    displayName: Mariner 2.0 amd64
-    condition: eq(variables['run.EFLOW.amd64'], true)
-    pool:
-      name: $(pool.linux.name)
-      demands:
-        - ImageOverride -equals agent-aziotedge-mariner-2.0-msmoby
+# ################################################################################
+#   - job: mariner2_amd64
+# ################################################################################
+#     displayName: Mariner 2.0 amd64
+#     condition: eq(variables['run.EFLOW.amd64'], true)
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#         - ImageOverride -equals agent-aziotedge-mariner-2.0-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-mariner2-amd64
-      identityServiceArtifactName: packages_mariner-2_amd64
-      identityServicePackageFilter: aziot-identity-service-*.cm2.x86_64.rpm
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-mariner2-amd64
+#       identityServiceArtifactName: packages_mariner-2_amd64
+#       identityServicePackageFilter: aziot-identity-service-*.cm2.x86_64.rpm
 
-    timeoutInMinutes: 90
+#     timeoutInMinutes: 90
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: mariner2_arm64
-################################################################################
-    displayName: Mariner 2.0 arm64
-    condition: eq(variables['run.EFLOW.arm64'], true)
-    pool:
-      name: $(pool.linux.arm.name)
-      demands:
-        - ImageOverride -equals agent-aziotedge-mariner-2.0-arm64-msmoby
+# ################################################################################
+#   - job: mariner2_arm64
+# ################################################################################
+#     displayName: Mariner 2.0 arm64
+#     condition: eq(variables['run.EFLOW.arm64'], true)
+#     pool:
+#       name: $(pool.linux.arm.name)
+#       demands:
+#         - ImageOverride -equals agent-aziotedge-mariner-2.0-arm64-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-mariner2-aarch64
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-mariner2-aarch64
 
-    timeoutInMinutes: 90
+#     timeoutInMinutes: 90
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -26,148 +26,148 @@ variables:
 
 jobs:
 
-# ################################################################################
-#   - job: debian_11_arm32v7
-# ################################################################################
-#     displayName: Debian 11 arm32v7
+################################################################################
+  - job: debian_11_arm32v7
+################################################################################
+    displayName: Debian 11 arm32v7
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands: deb11-e2e-tests
+    pool:
+      name: $(pool.custom.name)
+      demands: deb11-e2e-tests
 
-#     variables:
-#       os: linux
-#       arch: arm32v7
-#       artifactName: iotedged-debian11-arm32v7
-#       identityServiceArtifactName: packages_debian-11-slim_arm32v7
-#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+    variables:
+      os: linux
+      arch: arm32v7
+      artifactName: iotedged-debian11-arm32v7
+      identityServiceArtifactName: packages_debian-11-slim_arm32v7
+      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: debian_10_arm32v7
-# ################################################################################
-#     displayName: Debian 10 arm32v7 (minimal)
+################################################################################
+  - job: debian_10_arm32v7
+################################################################################
+    displayName: Debian 10 arm32v7 (minimal)
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands: deb10-e2e-tests
+    pool:
+      name: $(pool.custom.name)
+      demands: deb10-e2e-tests
 
-#     variables:
-#       os: linux
-#       arch: arm32v7
-#       artifactName: iotedged-debian10-arm32v7
-#       identityServiceArtifactName: packages_debian-10-slim_arm32v7
-#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
-#       minimal: true
+    variables:
+      os: linux
+      arch: arm32v7
+      artifactName: iotedged-debian10-arm32v7
+      identityServiceArtifactName: packages_debian-10-slim_arm32v7
+      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+      minimal: true
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: ubuntu_2004_msmoby
-# ################################################################################
-#     displayName: Ubuntu 20.04 with iotedge-moby
+################################################################################
+  - job: ubuntu_2004_msmoby
+################################################################################
+    displayName: Ubuntu 20.04 with iotedge-moby
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu20.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu20.04-amd64
+      identityServiceArtifactName: packages_ubuntu-20.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-#     timeoutInMinutes: 90
+    timeoutInMinutes: 90
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: ubuntu_2004_docker
-# ################################################################################
-#     displayName: Ubuntu 20.04 with Docker (minimal)
+################################################################################
+  - job: ubuntu_2004_docker
+################################################################################
+    displayName: Ubuntu 20.04 with Docker (minimal)
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu20.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-#       minimal: true
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu20.04-amd64
+      identityServiceArtifactName: packages_ubuntu-20.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      minimal: true
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: ubuntu_2004_arm64v8
-# ################################################################################
-#     displayName: Ubuntu 20.04 on arm64v8
-#     pool:
-#       name: $(pool.linux.arm.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
+################################################################################
+  - job: ubuntu_2004_arm64v8
+################################################################################
+    displayName: Ubuntu 20.04 on arm64v8
+    pool:
+      name: $(pool.linux.arm.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
 
-#     variables:
-#       os: linux
-#       arch: arm64v8
-#       artifactName: iotedged-ubuntu20.04-aarch64
-#       identityServiceArtifactName: packages_ubuntu-20.04_aarch64
-#       identityServicePackageFilter: aziot-identity-service_*_arm64.deb
+    variables:
+      os: linux
+      arch: arm64v8
+      artifactName: iotedged-ubuntu20.04-aarch64
+      identityServiceArtifactName: packages_ubuntu-20.04_aarch64
+      identityServicePackageFilter: aziot-identity-service_*_arm64.deb
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: ubuntu_2204
-# ################################################################################
-#     displayName: Ubuntu 22.04 on amd64
+################################################################################
+  - job: ubuntu_2204
+################################################################################
+    displayName: Ubuntu 22.04 on amd64
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu22.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-22.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu22.04-amd64
+      identityServiceArtifactName: packages_ubuntu-22.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-#     timeoutInMinutes: 90
+    timeoutInMinutes: 90
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_2204_arm64v8
@@ -194,144 +194,144 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: centos7_amd64
-# ################################################################################
-#     displayName: CentOs7 amd64
+################################################################################
+  - job: centos7_amd64
+################################################################################
+    displayName: CentOs7 amd64
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-centos-7-msmoby
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-centos-7-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-centos7-amd64
-#       identityServiceArtifactName: packages_centos-7_amd64
-#       identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-centos7-amd64
+      identityServiceArtifactName: packages_centos-7_amd64
+      identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
-#   ################################################################################
-#   - job: redhat8_amd64
-#   ################################################################################
-#     displayName: RedHat8 amd64
+  ################################################################################
+  - job: redhat8_amd64
+  ################################################################################
+    displayName: RedHat8 amd64
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-rhel-8-msmoby
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-rhel-8-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-redhat8-amd64
-#       identityServiceArtifactName: packages_redhat-ubi8-latest_amd64
-#       identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-redhat8-amd64
+      identityServiceArtifactName: packages_redhat-ubi8-latest_amd64
+      identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
-#   ################################################################################
-#   - job: redhat9_amd64
-#   ################################################################################
-#     displayName: RedHat9 amd64
+  ################################################################################
+  - job: redhat9_amd64
+  ################################################################################
+    displayName: RedHat9 amd64
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-rhel-9-msmoby
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-rhel-9-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-redhat9-amd64
-#       identityServiceArtifactName: packages_redhat-ubi9-latest_amd64
-#       identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-redhat9-amd64
+      identityServiceArtifactName: packages_redhat-ubi9-latest_amd64
+      identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: linux_amd64_proxy
-# ################################################################################
-#     displayName: Linux amd64 behind a proxy
+################################################################################
+  - job: linux_amd64_proxy
+################################################################################
+    displayName: Linux amd64 behind a proxy
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands: new-e2e-proxy
+    pool:
+      name: $(pool.custom.name)
+      demands: new-e2e-proxy
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu20.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-#       # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
-#       'agent.disablelogplugin.testfilepublisherplugin': true
-#       'agent.disablelogplugin.testresultlogplugin': true
-#       # because we aren't publishing test artifacts for this job, turn on verbose logging instead
-#       verbose: true
-#       # skip component governance detection to avoid proxy issues. It is checked in the other jobs.
-#       skipComponentGovernanceDetection: true
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu20.04-amd64
+      identityServiceArtifactName: packages_ubuntu-20.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
+      'agent.disablelogplugin.testfilepublisherplugin': true
+      'agent.disablelogplugin.testresultlogplugin': true
+      # because we aren't publishing test artifacts for this job, turn on verbose logging instead
+      verbose: true
+      # skip component governance detection to avoid proxy issues. It is checked in the other jobs.
+      skipComponentGovernanceDetection: true
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
-#       parameters:
-#         test_type: http_proxy
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
+      parameters:
+        test_type: http_proxy
 
-# ################################################################################
-#   - job: mariner2_amd64
-# ################################################################################
-#     displayName: Mariner 2.0 amd64
-#     condition: eq(variables['run.EFLOW.amd64'], true)
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#         - ImageOverride -equals agent-aziotedge-mariner-2.0-msmoby
+################################################################################
+  - job: mariner2_amd64
+################################################################################
+    displayName: Mariner 2.0 amd64
+    condition: eq(variables['run.EFLOW.amd64'], true)
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-mariner-2.0-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-mariner2-amd64
-#       identityServiceArtifactName: packages_mariner-2_amd64
-#       identityServicePackageFilter: aziot-identity-service-*.cm2.x86_64.rpm
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-mariner2-amd64
+      identityServiceArtifactName: packages_mariner-2_amd64
+      identityServicePackageFilter: aziot-identity-service-*.cm2.x86_64.rpm
 
-#     timeoutInMinutes: 90
+    timeoutInMinutes: 90
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: mariner2_arm64
-# ################################################################################
-#     displayName: Mariner 2.0 arm64
-#     condition: eq(variables['run.EFLOW.arm64'], true)
-#     pool:
-#       name: $(pool.linux.arm.name)
-#       demands:
-#         - ImageOverride -equals agent-aziotedge-mariner-2.0-arm64-msmoby
+################################################################################
+  - job: mariner2_arm64
+################################################################################
+    displayName: Mariner 2.0 arm64
+    condition: eq(variables['run.EFLOW.arm64'], true)
+    pool:
+      name: $(pool.linux.arm.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-mariner-2.0-arm64-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-mariner2-aarch64
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-mariner2-aarch64
 
-#     timeoutInMinutes: 90
+    timeoutInMinutes: 90
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml


### PR DESCRIPTION
When we first created 1ES-hosted agents for Ubuntu 22.04, 1ES didn't support arm64 yet so we only enabled amd64. Any issues have since been resolved, so this change enables arm64 agents for the end-to-end test pipeline.