### PR TITLE
Use 1ES-hosted agent for Ubuntu 22.04 arm64

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -175,8 +175,9 @@ jobs:
     displayName: Ubuntu 22.04 on arm64v8
 
     pool:
-      name: $(pool.custom.name)
-      demands: ubu2204-arm64-e2e-tests
+      name: $(pool.linux.arm.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-22.04-arm64-msmoby
 
     variables:
       os: linux


### PR DESCRIPTION
Cherry-pick 7de3f430e1a2eea938e7bb1cbdbec94c707dd844