### PR TITLE
Don't `docker login` from IotEdgeCheck test

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -3,6 +3,14 @@ parameters:
   IotHubConnectionString: '$(TestIotHubConnectionString)'
   test_type: ''
 
+steps:
+  # Docker login required for the 'iotedge check' end-to-end test
+- task: Docker@2
+  displayName: Docker login edgebuilds
+  inputs:
+    command: login
+    containerRegistry: iotedge-edgebuilds-acr
+
 # This E2E test pipeline uses the following filters in order to skip certain tests:
 #   Flaky: Flaky on multiple platforms
 #   FlakyOnArm: Flaky only on arm
@@ -13,7 +21,6 @@ parameters:
 #   NestedEdgeAmqpOnly: Only applies to nested edge cases using amqp upstream protocol
 #   LegacyMqttRequired: Only applies to cases with the edgehub legacy mqtt protocol head
 #   Amd64Only: Only applies to amd64 architecture
-steps:
 - pwsh: |
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
     $test_type = '${{ parameters.test_type }}'

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         protected async Task BeforeAllTestsAsync()
         {
             using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
-            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.FirstOrDefault());
             this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(cts.Token);
         }
     }


### PR DESCRIPTION
The `iotedge check` end-to-end test was issuing a `docker login` command to ensure that the diagnostics image could be pulled even if it came from a different registry than Edge Agent and Edge Hub. That code has the potential to log docker credentials in the test output, so this change removes it. Also, while we may have needed to test with a diagnostics image from some other registry in the past, it's not necessary today. With these changes, the test simply assumes that the user running the tests has already given docker permissions to pull the diagnostics before running the test.

The change also updates the test name to be consistent with the naming convention of other end-to-end tests. It also removes an unused variable discovered in the test infrastructure code.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.