### PR TITLE
Quiet the aziot-edged.service log.

### DIFF
--- a/edgelet/aziot-edged/src/watchdog.rs
+++ b/edgelet/aziot-edged/src/watchdog.rs
@@ -79,7 +79,7 @@ async fn watchdog(
     runtime: &edgelet_docker::DockerModuleRuntime<http_common::Connector>,
     identity_client: &aziot_identity_client_async::Client,
 ) -> Result<(), EdgedError> {
-    log::info!("Watchdog checking Edge runtime status");
+    log::debug!("Watchdog checking Edge runtime status");
     let agent_name = settings.agent().name();
 
     if let Ok((_, agent_status)) = runtime.get(agent_name).await {
@@ -87,7 +87,7 @@ async fn watchdog(
 
         match agent_status {
             edgelet_core::ModuleStatus::Running => {
-                log::info!("Edge runtime is running");
+                log::debug!("Edge runtime is running");
             }
 
             edgelet_core::ModuleStatus::Stopped | edgelet_core::ModuleStatus::Failed => {

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -590,7 +590,7 @@ where
     }
 
     async fn system_resources(&self) -> anyhow::Result<SystemResources> {
-        log::info!("Querying system resources...");
+        log::debug!("Querying system resources...");
 
         let uptime = nix::sys::sysinfo::sysinfo()?.uptime().as_secs();
 


### PR DESCRIPTION
Currently, the messages modified by this commit frequently get added to the system log at the default INFO level.  Reduce these to DEBUG level to quiet the logs.


This PR partially addresses the issues raised in #5700 which has been open and unaddressed for a very long time.