### PR TITLE
Don't `docker login` from IotEdgeCheck test

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -66,7 +66,7 @@ jobs:
         displayName: Set Version
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
-      - script: "cargo install cross --version ^0.2"
+      - script: "cargo install cross --version ^0.2 --locked"
         displayName: "Install cross"
       - script: "cross build --target armv7-unknown-linux-gnueabihf"
         displayName: armv7-unknown-linux-gnueabihf build
@@ -97,7 +97,7 @@ jobs:
         displayName: Set Version
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
-      - script: "cargo install cross --version ^0.2"
+      - script: "cargo install cross --version ^0.2 --locked"
         displayName: "Install cross"
       - script: "cross build --target aarch64-unknown-linux-gnu"
         displayName: aarch64-unknown-linux-gnu build

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -3,6 +3,14 @@ parameters:
   IotHubConnectionString: '$(TestIotHubConnectionString)'
   test_type: ''
 
+steps:
+  # Docker login required for the 'iotedge check' end-to-end test
+- task: Docker@2
+  displayName: Docker login edgebuilds
+  inputs:
+    command: login
+    containerRegistry: iotedge-edgebuilds-acr
+
 # This E2E test pipeline uses the following filters in order to skip certain tests:
 #   Flaky: Flaky on multiple platforms
 #   FlakyOnArm: Flaky only on arm
@@ -13,7 +21,6 @@ parameters:
 #   NestedEdgeAmqpOnly: Only applies to nested edge cases using amqp upstream protocol
 #   LegacyMqttRequired: Only applies to cases with the edgehub legacy mqtt protocol head
 #   Amd64Only: Only applies to amd64 architecture
-steps:
 - pwsh: |
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
     $test_type = '${{ parameters.test_type }}'

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         protected async Task BeforeAllTestsAsync()
         {
             using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
-            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.FirstOrDefault());
             this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(cts.Token);
         }
     }


### PR DESCRIPTION
Cherry-pick 0ab3c0117e5a499d83f0c566739278d93f5109e9

Also, updated invocations of `cargo install cross` to use `--locked` because a cross dependency recently bumped its MSRV to 1.70, but our release branch still uses 1.65.