### PR TITLE
Add psmisc dependency to Debian package since the postrm script uses it.

### DIFF
--- a/edgelet/contrib/debian/control
+++ b/edgelet/contrib/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/azure/iotedge
 
 Package: aziot-edge
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, aziot-identity-service (= 1.4.0~dev-1), sed
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, psmisc, sed, aziot-identity-service (= 1.4.0~dev-1)
 Description: Azure IoT Edge Module Runtime
  Azure IoT Edge is a fully managed service that delivers cloud intelligence
  locally by deploying and running artificial intelligence (AI), Azure services,


### PR DESCRIPTION
Ref: Azure/iot-identity-service#578