### PR TITLE
bump snap base to core22

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -12,18 +12,6 @@ toml_new_section() {
 	printf "[%s]\n" "$1"
 }
 
-# Work around the fact that there is no consolidated, machine readable
-# output of `hostnamectl` in the version included in core20. Core22 will
-# be more elegant (i.e. `hostnamectl hostname`)
-get_hostname() {
-	hostname="$(/usr/bin/hostnamectl --static)"
-	if [ -z "$hostname" ] ; then
-		hostname="$(/usr/bin/hostnamectl --transient)"
-	fi
-
-	printf "$hostname"
-}
-
 # make sure we are plugged in to the identity service
 if ! snapctl is-connected identity-service; then
 	exit 0
@@ -34,11 +22,11 @@ mkdir -p /etc/aziot/edged/config.d
 snapctl get raw-config > /etc/aziot/config.toml
 
 {
-	toml_kvp "hostname" "$(get_hostname)"
+	toml_kvp "hostname" "$(hostnamectl hostname)"
 } | tee /etc/aziot/keyd/config.d/01-snap.toml /etc/aziot/certd/config.d/01-snap.toml /etc/aziot/identityd/config.d/01-snap.toml /etc/aziot/tpmd/config.d/01-snap.toml
 
 {
-	toml_kvp "hostname" "$(get_hostname)"
+	toml_kvp "hostname" "$(hostnamectl hostname)"
 
 	toml_new_section "agent"
 	toml_kvp "name" "edgeAgent"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,12 +10,8 @@ description: |
 confinement: strict # use 'strict' once you have the right plugs and slots
 adopt-info: edgelet
 
-# Use passthrough for the moment, until the appropriate snapcraft release lands
-# system-usernames:
-#   snap_aziotedge: shared
-passthrough:
-  system-usernames:
-    snap_aziotedge: shared
+system-usernames:
+  snap_aziotedge: shared
 
 package-repositories:
   - type: apt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: azure-iot-edge
-base: core20 # the base snap is the execution environment for this snap
+base: core22 # the base snap is the execution environment for this snap
 summary: Single-line elevator pitch for your amazing snap # 79 char long summary
 description: |
   This is my-snap's description. You have a paragraph or two to tell the
@@ -34,7 +34,7 @@ parts:
     override-build: |
       mkdir -p $HOME/.cargo/bin
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --profile minimal -y
-      cd $SNAPCRAFT_PROJECT_DIR/edgelet
+      cd $CRAFT_PROJECT_DIR/edgelet
       rustup update
   edgelet:
     after: [ rust-toolchain ]
@@ -55,14 +55,14 @@ parts:
       - USER_AZIOTTPM: "root"
       - USER_IOTEDGE: "snap_aziotedge"
     override-build: |
-      rm -rf $SNAPCRAFT_PART_BUILD/target
-      SC_VERSION="$(cat $SNAPCRAFT_PART_SRC/version.txt)"
-      snapcraftctl set-version "$SC_VERSION"
+      rm -rf $CRAFT_PART_BUILD/target
+      SC_VERSION="$(cat $CRAFT_PART_SRC/version.txt)"
+      craftctl set version="$SC_VERSION"
       # if version contains substing "dev" set grade to devel, else stable
       if test "${SC_VERSION#*dev}" != "$SC_VERSION" ; then
-        snapcraftctl set-grade devel
+        craftctl set grade=devel
       else
-        snapcraftctl set-grade stable
+        craftctl set grade=stable
       fi
       make install \
         PLATFORM_FEATURES=snapd \
@@ -70,7 +70,7 @@ parts:
         CONNECT_WORKLOAD_URI=unix:///var/run/iotedge/workload.sock \
         LISTEN_MANAGEMENT_URI=unix:///var/run/iotedge/mgmt.sock \
         LISTEN_WORKLOAD_URI=unix:///var/run/iotedge/workload.sock \
-        DESTDIR=$SNAPCRAFT_PART_INSTALL
+        DESTDIR=$CRAFT_PART_INSTALL
     build-packages:
       - binutils
       - build-essential
@@ -78,7 +78,6 @@ parts:
       - curl
       - cmake
       - debhelper
-      - dh-systemd
       - file
       - git
       - make


### PR DESCRIPTION
migrate to base: core22. this also entails a slight shift in snapcraft syntax (documented [here](https://forum.snapcraft.io/t/micro-howto-migrate-from-core20-to-core22/30188))
