### PR TITLE
Fix workspace manifest to use E2021 resolver.

### DIFF
--- a/edgelet/Cargo.toml
+++ b/edgelet/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "iotedge",
     "support-bundle",
 ]
+resolver = "2"
 
 [profile.dev]
 panic = 'abort'


### PR DESCRIPTION
While individual crates default to resolver v2 if they are E2021, workspaces are virtual manifests with no edition so they continue to default to resolver v1. cargo raises a warning about this but only sometimes, so this wasn't easily noticeable.

This change fixes the workspace manifest to use resolver v2.