### PR TITLE
Change API Proxy module build to use Debian 12 base image for ARM images.

### DIFF
--- a/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
@@ -8,6 +8,7 @@ FROM arm32v7/nginx:1.25
 WORKDIR /app
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y libcap2-bin && \
     rm -rf /var/lib/apt/lists/*
 RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx

--- a/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
@@ -8,6 +8,7 @@ FROM arm64v8/nginx:1.25
 WORKDIR /app
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y libcap2-bin && \
     rm -rf /var/lib/apt/lists/*
 RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx

--- a/scripts/linux/buildAPIProxy.sh
+++ b/scripts/linux/buildAPIProxy.sh
@@ -145,9 +145,9 @@ build_project()
     if [[ "$ARCH" == "amd64" ]]; then
         execute scripts/linux/cross-platform-rust-build.sh --os alpine --arch "amd64" --build-path edge-modules/api-proxy-module
     elif [[ "$ARCH" == "arm32v7" ]]; then
-        execute scripts/linux/cross-platform-rust-build.sh --os ubuntu20.04 --arch "arm32v7" --build-path edge-modules/api-proxy-module
+        execute scripts/linux/cross-platform-rust-build.sh --os debian12 --arch "arm32v7" --build-path edge-modules/api-proxy-module
     elif [[ "$ARCH" == "arm64v8" ]]; then
-        execute scripts/linux/cross-platform-rust-build.sh --os ubuntu20.04 --arch "aarch64" --build-path edge-modules/api-proxy-module
+        execute scripts/linux/cross-platform-rust-build.sh --os debian12 --arch "aarch64" --build-path edge-modules/api-proxy-module
     else
         echo "Cannot run script Unsupported architecture $ARCH"
         exit 1


### PR DESCRIPTION
The base image of the module container uses `arm32v7/nginx` and `arm64v8/nginx` which are based on Debian 12, which uses OpenSSL v3. Before this change, we were building the binary itself in an Ubuntu 20.04 container so it would link to OpenSSL v1.1 instead and fail to run inside the Debian 12 containers.

This change fixes the build script to use a Debian 12 base image instead.