### PR TITLE
snapping: docker path fix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -148,7 +148,7 @@ hooks:
       - mount-observe
 
 environment:
-  PATH: "$PATH:$SNAP/aziotctl/bin"
+  PATH: "$PATH:$SNAP/aziotctl/bin:$SNAP/usr/bin"
 
 plugs:
   aziotctl-executables:


### PR DESCRIPTION
Make sure the docker executable is in the $PATH