### PR TITLE
Update to the latest identity service commit ref

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "serde",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "http-common",
  "libc",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "pkcs11",
  "serde",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "http-common",
  "serde",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "serde",
  "toml",
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -1519,7 +1519,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "env_logger",
  "log",
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "cc",
 ]
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1777,7 +1777,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 
 [[package]]
 name = "pkg-config"
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#1ad9c6a45620f9439ade40463b5f4de8884748e5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#98419cedde7513091af23b6b08bd6c52bb262b0f"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",


### PR DESCRIPTION
We haven't updated iotedge@main's reference to iot-identity-service in a little while. Automation uses the reference to figure out which identity service package to download for test scenarios, but when the reference gets too old, GitHub Actions deletes the packages. The change updates the reference.

The checks for this PR will give the needed test coverage.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.