### PR TITLE
Fix problems with snap release

### DIFF
--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -383,8 +383,7 @@ stages:
         sudo snap install snapcraft --classic
         for pkg in $(ls $(System.ArtifactsDirectory)/**/*.snap)
         do
-          # TODO: change release channel from 'edge' to 'stable'
-          snapcraft upload --release=edge "$pkg"
+          snapcraft upload --release=stable "$pkg"
         done
 
         logdir='$(Build.ArtifactStagingDirectory)/logs'

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -172,7 +172,7 @@ stages:
     - script: |
         sudo snap install snapcraft --classic
         lxd init --minimal
-        snapcraft --use-lxd
+        SNAPCRAFT_BUILD_INFO=1 snapcraft --use-lxd
       displayName: Build snap
       env:
         SNAPCRAFT_BUILD_INFO: 1

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -166,7 +166,7 @@ stages:
           - script: |
               sudo snap install snapcraft --classic
               lxd init --minimal
-              snapcraft --use-lxd
+              SNAPCRAFT_BUILD_INFO=1 snapcraft --use-lxd
             displayName: Build snap
             condition: eq(${{ parameters['E2EBuild'] }}, false)
           - task: CopyFiles@2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,7 @@ parts:
       rm -rf $CRAFT_PART_BUILD/target
       SC_VERSION="$(cat $CRAFT_PART_SRC/version.txt)"
       craftctl set version="$SC_VERSION"
-      # if version contains substing "dev" set grade to devel, else stable
+      # if version contains substring "dev" set grade to devel, else stable
       if test "${SC_VERSION#*dev}" != "$SC_VERSION" ; then
         craftctl set grade=devel
       else


### PR DESCRIPTION
The change fixes a few problems with the snap builds and release:
1. Snaps weren't built with SNAPCRAFT_BUILD_INFO enabled, so they didn't generate SBOM info. I added the flag to snap builds. Note this isn't a problem for the azure-iot-identity snap because it's built using the snap action in our GitHub workflow, which automatically adds this option.
2. Snaps were published to the edge channel in the release build. This was intentional the first time, but we want to publish directly to the stable channel from now on.

To test, I ran the CI build pipeline and verified that the snaps have an SBOM.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.