### PR TITLE
Get service connection name from pipeline variable

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -139,9 +139,7 @@ jobs:
     timeoutInMinutes: 120
 
     steps:
-    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
 ################################################################################
@@ -164,9 +162,7 @@ jobs:
     timeoutInMinutes: 90
 
     steps:
-    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
 ################################################################################
@@ -189,9 +185,7 @@ jobs:
     timeoutInMinutes: 90
 
     steps:
-    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
 ################################################################################
@@ -249,9 +243,7 @@ jobs:
       identityServicePackageFilter: aziot-identity-service-?.*.x86_64.rpm
 
     steps:
-    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
   ################################################################################

--- a/builds/e2e/templates/e2e-clear-docker-cached-images.yaml
+++ b/builds/e2e/templates/e2e-clear-docker-cached-images.yaml
@@ -1,9 +1,9 @@
 steps:
 - task: Docker@2
-  displayName: Docker login edgebuilds
+  displayName: Docker login
   inputs:
     command: login
-    containerRegistry: iotedge-edgebuilds-acr
+    containerRegistry: $(service-connection.registry)
 
 - pwsh: |
     # We use a self-hosted agent for this job, so we need to clean up


### PR DESCRIPTION
We changed a service connection in some of our pipelines and a hard-coded reference broke. This change updates the reference to a pipeline variable like all the other references in the repo.

Also, we have some special templates which are invoked in the end-to-end test pipeline from jobs that run on custom, stateful agents. The templates clean up build files and Docker images that may be hanging around from previous runs. Over time, we've switched several jobs to use stateless agents, but those jobs continue to invoke the templates. I removed references where they're no longer needed.

To test, I ran the end-to-end test pipeline and verified that it passed.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.