### PR TITLE
Update changelog creation in auto-refresh image releases

### DIFF
--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -344,10 +344,8 @@ get_metrics_collector_release_info() {
 }
 
 #
-# Uses the GitHub API to create a GitHub Release page in the *product* repo for a release that only
-# refreshes our core Docker images (agent, hub, temp sensor and diagnostics) when their base images
-# have been updated (i.e., no code changes in our project repo). Returns an error status code if
-# the required environment variables are empty, or if GitHub returns an error.
+# Uses the GitHub API to create a GitHub Release page in the *product* repo. Returns an error status
+# code if the required environment variables are empty, or if GitHub returns an error.
 #
 # Globals
 #   BRANCH       Optional. If not given, defaults to 'main'
@@ -416,10 +414,8 @@ create_github_release_page_in_product_repo() {
 }
 
 #
-# Uses the GitHub API to create a GitHub Release page in the *project* repo for a release that only
-# refreshes our core Docker images (agent, hub, temp sensor and diagnostics) when their base images
-# have been updated (i.e., no code changes in our project repo). Returns an error status code if
-# the required environment variables are empty, or if GitHub returns an error.
+# Uses the GitHub API to create a GitHub Release page in the *project* repo. Returns an error status
+# code if the required environment variables are empty, or if GitHub returns an error.
 #
 # Globals
 #   BRANCH       Optional. If not given, defaults to current branch (e.g., 'release/1.4')
@@ -480,10 +476,8 @@ create_github_release_page_for_core_images_in_project_repo() {
 }
 
 #
-# Uses the GitHub API to create a GitHub Release page in the *project* repo for a release that only
-# refreshes our Metrics Collector Docker images when their base images have been updated (i.e., no
-# code changes in our project repo). Returns an error status code if the required environment
-# variables are empty, or if GitHub returns an error.
+# Uses the GitHub API to create a GitHub Release page in the *project* repo. Returns an error status
+# code if the required environment variables are empty, or if GitHub returns an error.
 #
 # Globals
 #   COMMITISH    Optional. If not given, defaults to current branch (e.g., 'release/1.4')

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -69,6 +69,8 @@ local filepath="$3"
 cat <<- EOF > "$filepath"
 # $prod_version ($(date --iso-8601=date))
 
+Only Docker images are updated in this release. The daemon remains at version $diag_version.
+
 The following Docker images were updated because their base images changed:
 * azureiotedge-agent
 * azureiotedge-hub
@@ -371,16 +373,13 @@ create_github_release_page_in_product_repo() {
     return 1
   fi
 
+  local body="$CHANGELOG"
   local branch=${BRANCH:-main}
   local is_lts=${IS_LTS:-false}
   local name="$CORE_VERSION"
   if [ "$is_lts" != "false" ]; then
     name+=" LTS"
   fi
-
-  local body='Only Docker images are updated in this release.'
-  body+=$(echo -e " The daemon remains at version $DIAG_VERSION.\n\n")
-  body+="$CHANGELOG"
 
   local data=$(jq -nc \
     --arg version "$CORE_VERSION" \


### PR DESCRIPTION
When the auto-refresh pipeline runs to update core module images (Edge Agent, Edge Hub, Simulated Temperature Sensor, and Diagnostics) following a base image update, we generate boilerplate text that goes into the [changelog](https://github.com/Azure/iotedge/blob/release/1.4/CHANGELOG.md) and the [GitHub release](https://github.com/Azure/azure-iotedge/releases). For no good reason, the message in the changelog is slightly different from the message in the release page--specifically, we prepend some extra information in the release page.

This change makes the two changelogs consistent. It will allow us to use a single pipeline for both manual and auto-refresh releases. I also updated the comment headers in a couple bash script functions to make it clear that they are usefull in both auto-refresh and manual release scenarios.

To test, I ran the release pipeline in a test environment and confirmed that the changelogs contain the expected information.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.