### PR TITLE
Fix snap builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,11 +25,14 @@ parts:
     plugin: nil
     build-packages:
       - curl
+      - sed
     build-environment:
       - PATH: "$PATH:$HOME/.cargo/bin"
     override-build: |
       mkdir -p $HOME/.cargo/bin
-      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --profile minimal -y
+      CHANNEL=$(sed -n '/^channel *=* */{s///;s/^"//;s/"$//;p;}' $CRAFT_PROJECT_DIR/rust-toolchain.toml)
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- --no-modify-path --profile minimal -y --default-toolchain $CHANNEL
       cd $CRAFT_PROJECT_DIR/edgelet
       rustup update
   edgelet:


### PR DESCRIPTION
This ensures that the snap's `rustup` honors `rust-toolchain.toml`.

[damonbarry] To test, I ran the CI Build pipeline against these changes and confirmed that snap builds pass.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.