### PR TITLE
Turn off debug symbols for snaps

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "serde",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "http-common",
  "libc",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "pkcs11",
  "serde",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "http-common",
  "serde",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "serde",
  "toml",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -1499,7 +1499,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "env_logger",
  "log",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "cc",
 ]
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1757,7 +1757,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 
 [[package]]
 name = "pkg-config"
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#82936fbf7cfaaee3c3b1a6e72cabcccb2700d52d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#d7ee2ee1ff8ee72a199841ea0414cbc48cab4c0e"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/Cargo.toml
+++ b/edgelet/Cargo.toml
@@ -22,4 +22,6 @@ panic = 'abort'
 panic = 'abort'
 # Release builds will have full symbols. The packaging phase will strip symbols from binaries and
 # make them available in a separate package.
+# Notes: Snaps don't have a good story for debug symbols, so for now we'll override this setting in
+# the snapcraft.yaml file by setting CARGO_PROFILE_RELEASE_DEBUG=0.
 debug = 2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,6 +53,7 @@ parts:
       - USER_AZIOTID: "root"
       - USER_AZIOTTPM: "root"
       - USER_IOTEDGE: "snap_aziotedge"
+      - CARGO_PROFILE_RELEASE_DEBUG: 0
     override-build: |
       rm -rf $CRAFT_PART_BUILD/target
       SC_VERSION="$(cat $CRAFT_PART_SRC/version.txt)"


### PR DESCRIPTION
There isn't currently a good way to package debuginfo and symbols for snaps. Since we're building with full symbols in cargo and they aren't being stripped out during the snap build, our snap packages are much larger than they should be. This change disables the [debug](https://doc.rust-lang.org/cargo/reference/profiles.html#debug) setting in the cargo release profile for snaps only.

To test, I built the amd64 snap locally with these changes. It went from 78 MB down to 21 MB. I also ran ran the end-to-end tests against built packages and confirmed everything passes.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.