### PR TITLE
Update pipeline to be using Service Principal instead of Service Account PAT

### DIFF
--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -46,7 +46,7 @@ stages:
       - template: templates/nested-get-secrets.yaml
       - script: scripts/linux/nestedAgentLock.sh -a "$(agent.group)" -b "$(Build.BuildId)" -n 1 -u "amqp"
         env:
-          PAT: "$(IotEdge1-PAT-msazure)"
+          PAT: "$(IotEdgePAT)"
         displayName: Lock agents for nested topology
         name: lock_test_agent
 

--- a/builds/e2e/templates/lock-test-agents.yaml
+++ b/builds/e2e/templates/lock-test-agents.yaml
@@ -14,6 +14,6 @@ jobs:
       - template: nested-get-secrets.yaml
       - script: scripts/linux/nestedAgentLock.sh -a "$(agent.group)" -b "$(Build.BuildId)" -n ${{ parameters['testRunnerCount'] }} -u ${{ parameters['upstream.protocol'] }}
         env:
-          PAT: "$(IotEdge1-PAT-msazure)"
+          PAT: "$(IotEdgePAT)"
         displayName: Lock agents for nested topology
         name: lock_test_agent

--- a/builds/e2e/templates/nested-get-secrets.yaml
+++ b/builds/e2e/templates/nested-get-secrets.yaml
@@ -15,7 +15,6 @@ steps:
         GitHubAccessToken,
         edgebuild-blob-core-connection-string,
         edgebuild-service-principal-secret,
-        IotEdge1-PAT-msazure
 
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: $(azure.keyVault)'
@@ -25,3 +24,20 @@ steps:
       SecretsFilter: >- 
         IotHub-ConnStr,
         IotHub-EventHubConnStr
+
+  - task: AzureCLI@2
+    displayName: 'Get PAT'
+    inputs:
+      azureSubscription: 'IoTEdge1-msazure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        # Note that the resoruce is specified to limit the token to Azure DevOps
+        aadTokenInfo=$(az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798")
+        if [ $? -ne 0 ]; then
+            echo "Could not acquire Azure DevOps token."
+            exit 40
+        fi
+        echo "Azure DevOps AAD token acquired.  Expires $(echo $aadTokenInfo | jq -r .expiresOn)"
+        aadToken=$(echo $aadTokenInfo | jq -r .accessToken)
+        echo "##vso[task.setvariable variable=IotEdgePAT;issecret=true]$aadToken"

--- a/builds/e2e/templates/unlock-test-agents.yaml
+++ b/builds/e2e/templates/unlock-test-agents.yaml
@@ -5,7 +5,7 @@ steps:
     env:
       POOL_ID: 123
       API_VER: 6.0
-      PAT: "$(IotEdge1-PAT-msazure)"
+      PAT: "$(IotEdgePAT)"
       BUILD_ID: $(Build.BuildId)
     inputs:
       targetType: inline

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -624,14 +624,6 @@ stages:
     steps:
     - checkout: azure-iotedge
     - checkout: self
-    - task: AzureKeyVault@1
-      displayName: Get secrets
-      inputs:
-        azureSubscription: $(az.subscription)
-        keyVaultName: $(kv.name)
-        secretsFilter: >-
-          IotEdge1-PAT-msazure
-
     - bash: |
         # Source the scripts & Update version files
         source $(Build.SourcesDirectory)/iotedge/scripts/linux/smokeTestHelper.sh
@@ -711,6 +703,24 @@ stages:
           "$(IsCheckPreviousPkg)"
       displayName: Released Artifacts Smoke Tests
 
+    - task: AzureCLI@2
+      condition: always()
+      displayName: 'Get PAT'
+      inputs:
+        azureSubscription: 'IoTEdge1-msazure'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          # Note that the resoruce is specified to limit the token to Azure DevOps
+          aadTokenInfo=$(az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798")
+          if [ $? -ne 0 ]; then
+              echo "Could not acquire Azure DevOps token."
+              exit 40
+          fi
+          echo "Azure DevOps AAD token acquired.  Expires $(echo $aadTokenInfo | jq -r .expiresOn)"
+          aadToken=$(echo $aadTokenInfo | jq -r .accessToken)
+          echo "##vso[task.setvariable variable=IotEdgePAT;issecret=true]$aadToken"
+
     - bash: |
         # Source the scripts & Update version files
         source $(Build.SourcesDirectory)/iotedge/scripts/linux/smokeTestHelper.sh
@@ -718,4 +728,4 @@ stages:
         test-released-images "$(Build.SourceBranchName)"
       displayName: Released Images Smoke Tests
       env:
-        DEVOPS_PAT: "$(IotEdge1-PAT-msazure)"
+        DEVOPS_PAT: "$(IotEdgePAT)"


### PR DESCRIPTION
Update pipeline to be using Service Principal instead of Service Account PAT

Update the following build pipelines to be using Service Principal for authentication to resources endpoints instead of using the Service Account PAT:
- Nested pipelines
- ISA95
- Build release 
 
## Azure IoT Edge PR checklist:

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
