### PR TITLE
Get identity service version from source instead of tag

### DIFF
--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -318,7 +318,12 @@ stages:
               set -ex
               git clone --recurse-submodules --branch main https://github.com/Azure/iot-identity-service.git
               pushd iot-identity-service
-              packageVersion=$(git tag | grep 1.5.[0-9]*$ | sort --version-sort -r | head -1)
+              packageVersion=$(
+                grep "PACKAGE_VERSION:" iot-identity-service/.github/workflows/packages.yaml
+                | awk '{print $2}'
+                | tr -d "'"
+                | tr -d '"'
+              )
               sudo docker run --rm \
                 -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
                 -e "ARCH=$PACKAGE_ARCH" \

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -319,7 +319,7 @@ stages:
               git clone --recurse-submodules --branch main https://github.com/Azure/iot-identity-service.git
               pushd iot-identity-service
               packageVersion=$(
-                grep "PACKAGE_VERSION:" iot-identity-service/.github/workflows/packages.yaml \
+                grep "PACKAGE_VERSION:" .github/workflows/packages.yaml \
                 | awk '{print $2}' \
                 | tr -d "'" \
                 | tr -d '"'

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -319,9 +319,9 @@ stages:
               git clone --recurse-submodules --branch main https://github.com/Azure/iot-identity-service.git
               pushd iot-identity-service
               packageVersion=$(
-                grep "PACKAGE_VERSION:" iot-identity-service/.github/workflows/packages.yaml
-                | awk '{print $2}'
-                | tr -d "'"
+                grep "PACKAGE_VERSION:" iot-identity-service/.github/workflows/packages.yaml \
+                | awk '{print $2}' \
+                | tr -d "'" \
                 | tr -d '"'
               )
               sudo docker run --rm \

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -175,9 +175,9 @@ update_product_versions_json()
     proposedEdgeletVersion=$(cat $IOTEDGE_REPO_PATH/edgelet/version.txt)
     proposedCoreImageVersion=$(cat $IOTEDGE_REPO_PATH/versionInfo.json | jq -r '.version')
     proposedIisVersion=$(
-        grep "PACKAGE_VERSION:" $IIS_REPO_PATH/.github/workflows/packages.yaml
-        | awk '{print $2}'
-        | tr -d "'"
+        grep "PACKAGE_VERSION:" $IIS_REPO_PATH/.github/workflows/packages.yaml \
+        | awk '{print $2}' \
+        | tr -d "'" \
         | tr -d '"'
     )
 


### PR DESCRIPTION
The Mariner arm64 build is currently failing. When it builds identity service bits, it tries to populate the version by getting the latest 1.5.* tag from the identity service repo. There are no 1.5.* tags yet, so it sends an empty version which causes `make` to fail.

The root cause is that we bumped our release version in code much sooner than we normally do (i.e., the period of time between bumping the version in code and actually publishing the bits is usually hours, but this time it's a couple weeks).

The fix is to extract the version from checked-in sources rather than git tag, since the tag isn't set until after we release.

To test, I ran the CI Build pipeline and confirmed that Mariner arm64 passes.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.