### PR TITLE
Fix Service Deployment pipeline

### DIFF
--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -50,7 +50,7 @@ steps:
     $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
     dotnet build $testDir
 
-    $binDir = Convert-Path "$testDir/bin/Debug/net6.0"
+    $binDir = Convert-Path "$testDir/bin/Debug/net8.0"
     Write-Output "##vso[task.setvariable variable=binDir]$binDir"
   displayName: Build tests
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -96,20 +96,10 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
 
         public string[] GetInstallCommandsFromMicrosoftProd(Option<Uri> proxy)
         {
-            // we really support only two options for now.
-            string repository = this.os.ToLower() switch
-            {
-                "ubuntu" => $"https://packages.microsoft.com/config/ubuntu/{this.version}/prod.list",
-                "debian" => $"https://packages.microsoft.com/config/debian/{this.version}/prod.list",
-                _ => throw new NotImplementedException($"Don't know how to install daemon for '{this.os}'"),
-            };
-
             return this.PackageExtension switch
             {
                 SupportedPackageExtension.Deb => new[]
                 {
-                    $"curl {repository} > /etc/apt/sources.list.d/microsoft-prod.list",
-                    "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
                     $"apt-get update",
                     $"apt-get install --option DPkg::Lock::Timeout=600 --yes aziot-edge"
                 },


### PR DESCRIPTION
This pipeline should probably have been updated in #7262 but was missed. This change:
- Updates the pipeline to look for test binaries in the net8.0 folder.
- Removes the code that registers packages.microsoft.com. The pipeline runners already have it, and they register it as signed with a specific keyring file, which may clash with the older style of registration found in the tests. With this change, we assume that the caller has registered the repo as a prerequisite.

I've tested that the pipeline passes with this change.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.