### PR TITLE
Push release commit before pushing tag

### DIFF
--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -151,16 +151,16 @@ make_project_release_commit_for_core_image_refresh() {
 
   local remote_url=$(get_push_url)
 
-  # commit changes, merge, and push
+  # commit changes and tag
   git commit -m "Prepare for release $next"
+  git tag "$next"
+  
+  # merge and push
   git fetch --prune "$remote"
   # check out the very latest to minimize possibility of a rejected push
   git checkout "refs/remotes/$remote/$branch"
   git merge "$next" -m "Merge tag '$next' into $branch"
   git push "$remote_url" "HEAD:$branch"
-
-  # tag the release commit
-  git tag "$next"
   git push "$remote_url" "$next"
 }
 
@@ -220,16 +220,16 @@ make_project_release_commit_for_metrics_collector_image_refresh() {
   local remote_url=$(get_push_url)
   local git_tag="${git_tag_prefix}${next}"
 
-  # commit changes, merge, and push
+  # commit changes and tag
   git commit -m "Prepare for Metrics Collector release $next"
+  git tag "$git_tag"
+
+  # merge and push
   git fetch --prune "$remote"
   # check out the very latest to minimize possibility of a rejected push
   git checkout "refs/remotes/$remote/$branch"
   git merge "$git_tag" -m "Merge tag '$git_tag' into $branch"
   git push "$remote_url" "HEAD:$branch"
-
-  # tag the release commit
-  git tag "$git_tag"
   git push "$remote_url" "$git_tag"
 }
 

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -151,17 +151,17 @@ make_project_release_commit_for_core_image_refresh() {
 
   local remote_url=$(get_push_url)
 
-  # commit changes, tag, and push
+  # commit changes, merge, and push
   git commit -m "Prepare for release $next"
-  git tag "$next"
-  git push "$remote_url" "$next"
-
-  # merge release commit and push
   git fetch --prune "$remote"
   # check out the very latest to minimize possibility of a rejected push
   git checkout "refs/remotes/$remote/$branch"
   git merge "$next" -m "Merge tag '$next' into $branch"
   git push "$remote_url" "HEAD:$branch"
+
+  # Tag the release commit
+  git tag "$next"
+  git push "$remote_url" "$next"
 }
 
 #

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -159,7 +159,7 @@ make_project_release_commit_for_core_image_refresh() {
   git merge "$next" -m "Merge tag '$next' into $branch"
   git push "$remote_url" "HEAD:$branch"
 
-  # Tag the release commit
+  # tag the release commit
   git tag "$next"
   git push "$remote_url" "$next"
 }
@@ -220,17 +220,17 @@ make_project_release_commit_for_metrics_collector_image_refresh() {
   local remote_url=$(get_push_url)
   local git_tag="${git_tag_prefix}${next}"
 
-  # commit changes, tag, and push
+  # commit changes, merge, and push
   git commit -m "Prepare for Metrics Collector release $next"
-  git tag "$git_tag"
-  git push "$remote_url" "$git_tag"
-
-  # merge release commit and push
   git fetch --prune "$remote"
   # check out the very latest to minimize possibility of a rejected push
   git checkout "refs/remotes/$remote/$branch"
   git merge "$git_tag" -m "Merge tag '$git_tag' into $branch"
   git push "$remote_url" "HEAD:$branch"
+
+  # tag the release commit
+  git tag "$git_tag"
+  git push "$remote_url" "$git_tag"
 }
 
 #


### PR DESCRIPTION
I noticed a problem today when .NET released new base images and our pipelines automatically triggered to update our core images. The pipeline created a release commit (locally, on the agent) with the updated changelog and versionInfo.json, but the commit failed to merge with the head of the branch, meaning we'll probably need to investigate the source of the merge problem, fix it manually, and re-run the pipeline--that's all fine. The problem is that the script _did_ manage to tag the release commit and push it upstream, so the pipeline re-run will fail to push the tag unless we manually clear it.

This change helps us prevent this problem in the future. It moves the tag push _after_ the merge commit push. I made the same change for both the core images release and the metrics collector image release.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.