### PR TITLE
Remove temporary workaround in end-to-end test for iotedge check

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
@@ -48,9 +48,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 });
             }
 
-            // TODO: Temporarily override expected aziot & iotedge versions until after we release 1.5.0
-            args += " --expected-aziot-version 1.5.0 --expected-aziot-edged-version 1.5.0";
-
             string errors_number = string.Empty;
 
             void OnStdout(string o)


### PR DESCRIPTION
There was a period of a few weeks between when we updated the version in the code to 1.5.0 and when we actually shipped 1.5.0. During that window of time, one of the end-to-end tests would have failed so we added a workaround. Now that we've shipped 1.5.0, this change removes the workaround.

I ran the end-to-end tests and verified that the IotEdgeCheck test passes.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.