### PR TITLE
Reduce pulls from docker.io

### DIFF
--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -225,7 +225,7 @@ stages:
                 -e "MARINER_ARCH=$MARINER_ARCH" \
                 -e "VERSION=$VERSION" \
                 --privileged \
-                "ubuntu:22.04" \
+                'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04' \
                 '/src/edgelet/build/linux/package-mariner.sh'
           - task: CopyFiles@2
             displayName: Copy iotedged build logs to artifact staging
@@ -331,7 +331,7 @@ stages:
                 -e "PACKAGE_VERSION=$packageVersion" \
                 -e "PACKAGE_RELEASE=1" \
                 --privileged \
-                "ubuntu:22.04" \
+                'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04' \
                 '/src/ci/package.sh'
               popd
               sudo cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-$packageVersion-1.cm$(os_version).$(arch).rpm .
@@ -347,7 +347,7 @@ stages:
                 -e "MARINER_ARCH=$MARINER_ARCH" \
                 -e "VERSION=$VERSION" \
                 --privileged \
-                "ubuntu:22.04" \
+                'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04' \
                 '/src/edgelet/build/linux/package-mariner.sh'
           - task: CopyFiles@2
             displayName: Copy iotedged build logs to artifact staging

--- a/edgelet/build/linux/package.sh
+++ b/edgelet/build/linux/package.sh
@@ -52,15 +52,15 @@ case "$PACKAGE_OS" in
         ;;
 
     'debian11')
-        DOCKER_IMAGE='debian:11-slim'
+        DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/debian:bullseye-slim'
         ;;
 
     'ubuntu20.04')
-        DOCKER_IMAGE='ubuntu:20.04'
+        DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/ubuntu:20.04'
         ;;
 
     'ubuntu22.04')
-        DOCKER_IMAGE='ubuntu:22.04'
+        DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/ubuntu:22.04'
         ;;
 esac
 

--- a/scripts/linux/cross-platform-rust-build.sh
+++ b/scripts/linux/cross-platform-rust-build.sh
@@ -68,11 +68,11 @@ DOCKER_VOLUME_MOUNTS=''
 
 case "$PACKAGE_OS" in
     'debian12')
-        DOCKER_IMAGE='debian:12-slim'
+        DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/debian:bookworm-slim'
         ;;
 
     'alpine')
-        DOCKER_IMAGE='ubuntu:20.04'
+        DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/ubuntu:20.04'
         ;;       
 esac
 


### PR DESCRIPTION
This change reduces the number of requests we make from various build pipelines to pull images from docker.io, which will reduce the chance that we get throttled by their rate limits.