### PR TITLE
Remove client secret usage in pipelines (#7291)

### DIFF
--- a/builds/e2e/compare-compatibility.yaml
+++ b/builds/e2e/compare-compatibility.yaml
@@ -47,14 +47,13 @@ jobs:
         azureSubscription: $(az.subscription)
         KeyVaultName: $(az.keyvault)
         SecretsFilter: >-
-          edgebuild-service-principal-secret,
-    - task: Bash@3
-      displayName: 'Az login'
+          edgebuild-service-principal-secret
+    - task: AzureCLI@2
       inputs:
+        azureSubscription: 'IoTEdge1-msazure'
+        scriptType: 'bash'
         targetType: inline
         script: |
-          az login --service-principal -p $(edgebuild-service-principal-secret) -u $(servicePrincipal.clientId) --tenant $(servicePrincipal.tenantId)
-    - bash: |
           contextPath=$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test/bin/Debug/net6.0/context.json
           mkdir -p $(Build.ArtifactStagingDirectory)/compat
           edgeAgentImage="$(cat $contextPath | jq '.edgeAgentImage' | tr -d '"')" 

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -79,14 +79,6 @@ stages:
     steps:
       - template: templates/nested-get-secrets.yaml
       - template: templates/e2e-clean-directory.yaml
-
-      - task: Bash@3
-        displayName: 'Az login'
-        inputs:
-          targetType: inline
-          script: |
-            az login --service-principal -p $(edgebuild-service-principal-secret) -u $(servicePrincipal.clientId) --tenant $(servicePrincipal.tenantId)
-
       - template: templates/nested-get-root-ca.yaml
       - template: templates/nested-get-device-name.yaml
       - template: templates/e2e-setup.yaml

--- a/builds/e2e/templates/nested-clean-identity.yaml
+++ b/builds/e2e/templates/nested-clean-identity.yaml
@@ -3,13 +3,15 @@ parameters:
   deviceId: ''
   lvl: ''
 
-steps:  
-  - task: Bash@3
+steps:
+  - task: AzureCLI@2
     displayName: 'Clean identity  ${{ parameters.lvl }}'
     condition: always()
     inputs:
-      targetType: inline
-      script: |
+      azureSubscription: 'IoTEdge1-msazure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
         deviceId="${{ parameters.deviceId }}"
 
         if [ -z $deviceId ]; then

--- a/builds/e2e/templates/nested-create-identity.yaml
+++ b/builds/e2e/templates/nested-create-identity.yaml
@@ -1,16 +1,12 @@
 steps: 
-  - task: Bash@3
-    displayName: 'Az login'
-    inputs:
-      targetType: inline
-      script: |     
-        az login --service-principal -p $(edgebuild-service-principal-secret) -u $(servicePrincipal.clientId) --tenant $(servicePrincipal.tenantId) 
-  - task: Bash@3
+  - task: AzureCLI@2
     displayName: 'Create identity'
     name: createIdentity
     inputs:
-      targetType: inline
-      script: |
+      azureSubscription: 'IoTEdge1-msazure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
         set -e
 
         echo "Extracting hub name from connection string"
@@ -21,6 +17,7 @@ steps:
         echo "Found Hub name: ${iotHubName}"
 
         az account set --subscription $(azure.subscription)
+        az config set extension.use_dynamic_install=yes_without_prompt
         deviceId="level_$(level)_$(Build.BuildId)$(upstreamProtocol)"
 
         echo "Creating ${deviceId} iotedge in iothub: ${iotHubName}, in subscription $(azure.subscription)"

--- a/builds/e2e/templates/nested-deploy-config.yaml
+++ b/builds/e2e/templates/nested-deploy-config.yaml
@@ -5,18 +5,21 @@ parameters:
   level: ''
   name: ''
 
-steps: 
-  - task: Bash@3
+steps:
+  - task: AzureCLI@2
     displayName: 'Deployment iotedge on agent'
     name: "deployIoTEdge${{ parameters.name }}"
+    env:
+      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
     inputs:
-      targetType: inline
-      script: |
+      azureSubscription: 'IoTEdge1-msazure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
         declare -a cnreg=( ${edgebuilds-azurecr-io-pwd} )
         . $(Build.StagingDirectory)/$(az.pipeline.images.artifacts)/artifactInfo.txt
 
         chmod +x $(Build.Repository.LocalPath)/scripts/linux/nested-edge-deploy-agent.sh
-
         sudo $(Build.Repository.LocalPath)/scripts/linux/nested-edge-deploy-agent.sh \
           -testDir "$(Agent.HomeDirectory)/.." \
           -releaseLabel "ct$(agent.group)" \
@@ -34,9 +37,13 @@ steps:
           -level "${{ parameters.level }}" \
           -parentName "$(parentName)" \
           -connectionString "$(connectionString)" \
-          -iotHubName "$(iotHubName)" \
-          -deviceId "${{ parameters.deviceId }}" \
           -proxyAddress "$(proxyAddress)" \
           -changeDeployConfigOnly "${{ parameters.changeDeployConfigOnly }}" \
           -waitForTestComplete \
-          -cleanAll
+          -cleanAll 
+          # -iotHubName "$(iotHubName)" \
+          # -deviceId "${{ parameters.deviceId }}" \
+
+          # 5/22/2024 - Temporary work around the issue where the az cli command cannot authorize itself within *.sh script using the service principal's service connection
+          deployment_working_file="$(Agent.HomeDirectory)/../working/deployment.json"
+          az iot edge set-modules --device-id "${{ parameters.deviceId }}" --hub-name "$(iotHubName)" --content ${deployment_working_file} --output none

--- a/builds/e2e/templates/nested-isa95-lock.yaml
+++ b/builds/e2e/templates/nested-isa95-lock.yaml
@@ -3,19 +3,15 @@ parameters:
   lvl: ''
 
 steps:
-  - task: Bash@3
+  - task: AzureCLI@2
     name: isa95_lock_lvl${{ parameters.lvl }}
     displayName: 'Locking network of ${{ parameters.agentName }}'
     inputs:
-      targetType: inline
-      script: |
+      azureSubscription: 'IoTEdge1-msazure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
         set -e
-
-        az login \
-          --service-principal \
-          --password '$(edgebuild-service-principal-secret)' \
-          --username '$(servicePrincipal.clientId)' \
-          --tenant '$(servicePrincipal.tenantId)'
 
         echo 'Get Network Interface'
         nic_resource=$(

--- a/builds/e2e/templates/nested-isa95-unlock.yaml
+++ b/builds/e2e/templates/nested-isa95-unlock.yaml
@@ -3,18 +3,14 @@ parameters:
   nsgName: ''
 
 steps: 
-  - task: Bash@3
+  - task: AzureCLI@2
     condition: always()
     displayName: 'Unlocking network of ${{ parameters.agentName }}'
     inputs:
-      targetType: inline
-      script: |     
-        az login \
-          --service-principal \
-          --password '$(edgebuild-service-principal-secret)' \
-          --username '$(servicePrincipal.clientId)' \
-          --tenant '$(servicePrincipal.tenantId)'
- 
+      azureSubscription: 'IoTEdge1-msazure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
         az network nsg rule delete \
           --resource-group '$(resourceGroup)' \
           --nsg-name '${{ parameters.nsgName }}' \

--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -122,8 +122,9 @@ function prepare_test_from_artifacts() {
 
     sudo cat ${deployment_working_file}
 
+    # 5/22/2024 - Temporary work around the issue where the az cli command cannot authorize itself within *.sh script using the service principal's service connection
     #deploy the config in azure portal
-    az iot edge set-modules --device-id ${DEVICE_ID} --hub-name ${IOT_HUB_NAME} --content ${deployment_working_file} --output none
+    #az iot edge set-modules --device-id ${DEVICE_ID} --hub-name ${IOT_HUB_NAME} --content ${deployment_working_file} --output none
 }
 
 function process_args() {
@@ -179,12 +180,13 @@ function process_args() {
         elif [ $saveNextArg -eq 16 ]; then
             CONNECTION_STRING="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 17 ]; then
-            DEVICE_ID="$arg"
-            saveNextArg=0
-        elif [ $saveNextArg -eq 18 ]; then
-            IOT_HUB_NAME="$arg"
-            saveNextArg=0
+        # 5/22/2024 - Temporary work around the issue where the az cli command cannot authorize itself within *.sh script using the service principal's service connection                
+        # elif [ $saveNextArg -eq 17 ]; then
+        #     DEVICE_ID="$arg"
+        #     saveNextArg=0
+        # elif [ $saveNextArg -eq 18 ]; then
+        #     IOT_HUB_NAME="$arg"
+        #     saveNextArg=0
         elif [ $saveNextArg -eq 19 ]; then
             PROXY_ADDRESS="$arg"
             saveNextArg=0
@@ -226,7 +228,8 @@ function process_args() {
     done
 
     # Required parameters
-    [[ -z "$DEVICE_ID" ]] && { print_error 'DEVICE_ID is required.'; exit 1; }
+    # 5/22/2024 - Temporary work around the issue where the az cli command cannot authorize itself within *.sh script using the service principal's service connection
+    # [[ -z "$DEVICE_ID" ]] && { print_error 'DEVICE_ID is required.'; exit 1; }
     [[ -z "$SUBSCRIPTION" ]] && { print_error 'SUBSCRIPTION is required.'; exit 1; }
     [[ -z "$LEVEL" ]] && { print_error 'Level is required.'; exit 1; }
     [[ -z "$ARTIFACT_IMAGE_BUILD_NUMBER" ]] && { print_error 'Artifact image build number is required'; exit 1; }


### PR DESCRIPTION
Cherry-picked: https://github.com/Azure/iotedge/commit/9b41182a50a564f582941177feeddbca3ed7e18a
- Remove the client secret
- Workaround the DevOps task where az cli cannot authorize itself within bash script in AzCLI task

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
