### PR TITLE
Use AzureCLI task to download blob

### DIFF
--- a/builds/e2e/templates/nested-get-root-ca.yaml
+++ b/builds/e2e/templates/nested-get-root-ca.yaml
@@ -1,11 +1,13 @@
 steps:
-  - task: Bash@3
-    displayName: 'Get rootCA'
+  - task: AzureCLI@2
     condition: or(eq(variables['run.flag'], ''), eq(variables['run.flag'], 1))
+    displayName: 'Get rootCA'
     inputs:
-      targetType: inline
-      script: |
-        az storage blob download --file rootCA.tar.bz2 --container-name test-certificates --name test-certs.tar.bz2 --connection-string "$(edgebuild-blob-core-connection-string)"
+      azureSubscription: 'IoTEdge1-msazure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        az storage blob download --auth-mode login --blob-url 'https://edgebuild.blob.core.windows.net/test-certificates/test-certs.tar.bz2' --file rootCA.tar.bz2 
         tar -xjvf rootCA.tar.bz2
 
         #delete previous certs.

--- a/builds/e2e/templates/nested-get-secrets.yaml
+++ b/builds/e2e/templates/nested-get-secrets.yaml
@@ -13,7 +13,6 @@ steps:
         EdgeConnectivityStorageAccountConnString,
         EdgeLonghaulStorageAccountConnString,
         GitHubAccessToken,
-        edgebuild-blob-core-connection-string,
         edgebuild-service-principal-secret,
 
   - task: AzureKeyVault@1


### PR DESCRIPTION
The nested test pipelines (ISA-95 smoke tests, Nested end-to-end tests, Connectivity tests) download a blob and use its contents as the basis for some cert operations related to IoT Edge. It seems like we should be generating these files at runtime, but for now we simply need to be able to access the blob storage account without using shared keys.

This change embeds the `az storage blob download ...` command in the AzureCLI task so it has access to an identity via the service connection. Then it updates the command to authenticate using the available identity, rather than using a SAS token.

To test, I disabled shared key access on the storage account, then I ran the ISA-95 smoke tests and confirmed that they're able to download the blob (and the tests pass).

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.