### PR TITLE
Add SAS token support for nested and LH pipelines

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -97,7 +97,7 @@ jobs:
           test.testMode: 'LongHaul'
           test.useTRC: '$(useTRC)'
           test.deploymentFileName: 'long_haul_deployment.template.json'
-          testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
+          testResultCoordinator.blobStorageAccountUriWithSasToken: '$(testBlobStoreSas)'
           clientModuleTransportType: 'All'
 
 ################################################################################
@@ -158,7 +158,7 @@ jobs:
           test.testMode: 'LongHaul'
           test.useTRC: '$(useTRC)'
           test.deploymentFileName: 'long_haul_deployment_constrained.template.json'
-          testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
+          testResultCoordinator.blobStorageAccountUriWithSasToken: '$(testBlobStoreSas)'
           clientModuleTransportType: 'amqp'
 
 ################################################################################
@@ -219,7 +219,7 @@ jobs:
           test.testMode: 'LongHaul'
           test.useTRC: '$(useTRC)'
           test.deploymentFileName: 'long_haul_deployment_constrained.template.json'
-          testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
+          testResultCoordinator.blobStorageAccountUriWithSasToken: '$(testBlobStoreSas)'
           clientModuleTransportType: 'mqtt'
 
 ################################################################################
@@ -281,7 +281,7 @@ jobs:
           test.testMode: 'LongHaul'
           test.useTRC: '$(useTRC)'
           test.deploymentFileName: 'long_haul_deployment_constrained.template.json'
-          testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
+          testResultCoordinator.blobStorageAccountUriWithSasToken: '$(testBlobStoreSas)'
           clientModuleTransportType: 'amqp'
 
 ################################################################################
@@ -343,7 +343,7 @@ jobs:
           test.testMode: 'LongHaul'
           test.useTRC: '$(useTRC)'
           test.deploymentFileName: 'long_haul_deployment_constrained.template.json'
-          testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
+          testResultCoordinator.blobStorageAccountUriWithSasToken: '$(testBlobStoreSas)'
           clientModuleTransportType: 'mqtt'
 
 ################################################################################
@@ -409,6 +409,6 @@ jobs:
           test.testMode: 'LongHaul'
           test.useTRC: '$(useTRC)'
           test.deploymentFileName: 'long_haul_deployment.template.json'
-          testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
+          testResultCoordinator.blobStorageAccountUriWithSasToken: '$(testBlobStoreSas)'
           clientModuleTransportType: 'All'
           packageType: 'rpm'

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -32,7 +32,7 @@ parameters:
   test.testMode: ''
   test.useTRC: ''
   test.deploymentFileName: ''
-  testResultCoordinator.storageAccountConnectionString: ''
+  testResultCoordinator.blobStorageAccountUriWithSasToken: ''
   clientModuleTransportType: ''
   packageType: 'deb' 
 
@@ -91,7 +91,7 @@ steps:
             -metricsScrapeFrequencyInSecs "${{ parameters['metricsCollector.scrapeFrequencyInSecs'] }}" \
             -metricsUploadTarget "${{ parameters['metricsCollector.uploadTarget'] }}" \
             -deploymentFileName "${{ parameters['test.deploymentFileName'] }}" \
-            -storageAccountConnectionString "${{ parameters['testResultCoordinator.storageAccountConnectionString'] }}" \
+            -blobStorageAccountUriWithSasToken "$(testBlobStoreSas)" \
             -testRuntimeLogLevel "${{ parameters['test.runtimeLogLevel'] }}" \
             -testInfo "$testInfo" \
             -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \

--- a/builds/e2e/templates/longhaul-setup.yaml
+++ b/builds/e2e/templates/longhaul-setup.yaml
@@ -28,7 +28,6 @@ steps:
         SnitchLongHaulAlertUrl,
         kvLogAnalyticWorkspaceId,
         kvLogAnalyticSharedKey,
-        EdgeLonghaulStorageAccountConnString,
         GitHubAccessToken
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: $(azure.keyVault)'

--- a/builds/e2e/templates/nested-deploy-config.yaml
+++ b/builds/e2e/templates/nested-deploy-config.yaml
@@ -29,7 +29,7 @@ steps:
           -containerRegistryPassword "$(edgebuilds-azurecr-io-pwd)" \
           -iotHubConnectionString "$(IotHub-ConnStr)" \
           -deploymentFileName "${{ parameters.deploymentFile }}" \
-          -storageAccountConnectionString "$(EdgeConnectivityStorageAccountConnString)" \
+          -blobStorageAccountUriWithSasToken "$(testBlobStoreSas)" \
           -edgeRuntimeBuildNumber "$(Build.BuildNumber)" \
           -customEdgeAgentImage "$(customEdgeAgent.image)" \
           -customEdgeHubImage "$(customEdgeHub.image)" \

--- a/builds/e2e/templates/nested-get-secrets.yaml
+++ b/builds/e2e/templates/nested-get-secrets.yaml
@@ -10,8 +10,6 @@ steps:
         edgebuilds-azurecr-io-pwd,
         kvLogAnalyticWorkspaceId,
         kvLogAnalyticSharedKey,
-        EdgeConnectivityStorageAccountConnString,
-        EdgeLonghaulStorageAccountConnString,
         GitHubAccessToken,
         edgebuild-service-principal-secret,
 

--- a/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
@@ -59,7 +59,7 @@ jobs:
           metricsCollector.hostPlatform: '$(hostPlatform)'
           longHaul.parentHostname: '$(parentName)'
           longHaul.parentEdgeDevice: '$(parentDeviceId)'
-          testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
+          testResultCoordinator.blobStorageAccountUriWithSasToken: '$(testBlobStoreSas)'
           quickstart.package.name: '$(quickstart.package.name)'
           testInfo.testName: "${{ parameters['testInfo.testName'] }}"
           upstream.protocol: "${{ parameters['upstream.protocol'] }}"

--- a/builds/e2e/templates/nested-longhaul-deploy.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy.yaml
@@ -30,7 +30,7 @@ parameters:
   test.runtimeLogLevel: ''
   longHaul.parentHostname: ''
   longHaul.parentEdgeDevice: ''
-  testResultCoordinator.storageAccountConnectionString: ''
+  testResultCoordinator.blobStorageAccountUriWithSasToken: ''
   quickstart.package.name: ''
   upstream.protocol: ''
 
@@ -176,7 +176,7 @@ steps:
             -metricsScrapeFrequencyInSecs "${{ parameters['metricsCollector.scrapeFrequencyInSecs'] }}" \
             -metricsUploadTarget "${{ parameters['metricsCollector.uploadTarget'] }}" \
             -deploymentFileName "${{ parameters['test.deploymentFileName'] }}" \
-            -storageAccountConnectionString "${{ parameters['testResultCoordinator.storageAccountConnectionString'] }}" \
+            -blobStorageAccountUriWithSasToken "$(testBlobStoreSas)" \
             -testRuntimeLogLevel "${{ parameters['test.runtimeLogLevel'] }}" \
             -testInfo "$testInfo" \
             -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \

--- a/e2e_deployment_files/edgehub_restart_deployment.template.json
+++ b/e2e_deployment_files/edgehub_restart_deployment.template.json
@@ -229,8 +229,8 @@
               "IOT_HUB_CONNECTION_STRING": {
                 "value": "<IoTHubConnectionString>"
               },
-              "STORAGE_ACCOUNT_CONNECTION_STRING": {
-                "value": "<TestResultCoordinator.StorageAccountConnectionString>"
+              "BLOB_STORE_SAS": {
+                "value": "<testBlobStoreSas>"
               },
               "NetworkControllerRunProfile": {
                 "value": "<NetworkController.RunProfile>"

--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -406,8 +406,8 @@
               "logUploadEnabled": {
                 "value": "<TestResultCoordinator.logUploadEnabled>"
               },
-              "STORAGE_ACCOUNT_CONNECTION_STRING": {
-                "value": "<TestResultCoordinator.StorageAccountConnectionString>"
+              "BLOB_STORE_SAS": {
+                "value": "<testBlobStoreSas>"
               },
               "NetworkControllerRunProfile": {
                 "value": "<NetworkController.RunProfile>"

--- a/e2e_deployment_files/long_haul_deployment_constrained.template.json
+++ b/e2e_deployment_files/long_haul_deployment_constrained.template.json
@@ -262,8 +262,8 @@
                             "logUploadEnabled": {
                                 "value": "<TestResultCoordinator.logUploadEnabled>"
                             },
-                            "STORAGE_ACCOUNT_CONNECTION_STRING": {
-                                "value": "<TestResultCoordinator.StorageAccountConnectionString>"
+                            "BLOB_STORE_SAS": {
+                              "value": "<testBlobStoreSas>"
                             },
                             "NetworkControllerRunProfile": {
                                 "value": "<NetworkController.RunProfile>"

--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
@@ -385,8 +385,8 @@
               "logUploadEnabled": {
                 "value": "<TestResultCoordinator.logUploadEnabled>"
               },
-              "STORAGE_ACCOUNT_CONNECTION_STRING": {
-                "value": "<TestResultCoordinator.StorageAccountConnectionString>"
+              "BLOB_STORE_SAS": {
+                "value": "<testBlobStoreSas>"
               },
               "NetworkControllerRunProfile": {
                 "value": "<NetworkController.RunProfile>"

--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -154,7 +154,7 @@ function process_args() {
             IOT_HUB_CONNECTION_STRING="$arg"
             saveNextArg=0
         elif [ $saveNextArg -eq 8 ]; then
-            STORAGE_ACCOUNT_CONNECTION_STRING="$arg"
+            BLOB_STORE_SAS="$arg"
             saveNextArg=0
         elif [ $saveNextArg -eq 9 ]; then
             DEPLOYMENT_FILE_NAME="$arg"
@@ -203,7 +203,7 @@ function process_args() {
                 '-containerRegistryUsername' ) saveNextArg=5;;
                 '-containerRegistryPassword' ) saveNextArg=6;;
                 '-iotHubConnectionString' ) saveNextArg=7;;
-                '-storageAccountConnectionString' ) saveNextArg=8;;
+                '-blobStorageAccountUriWithSasToken' ) saveNextArg=8;;
                 '-deploymentFileName' ) saveNextArg=9;;
                 '-edgeRuntimeBuildNumber' ) saveNextArg=10;;
                 '-customEdgeAgentImage' ) saveNextArg=11;;
@@ -237,7 +237,7 @@ function process_args() {
     [[ -z "$CONTAINER_REGISTRY_PASSWORD" ]] && { print_error 'Container registry password is required'; exit 1; }
     [[ -z "$DEPLOYMENT_FILE_NAME" ]] && { print_error 'Deployment file name is required'; exit 1; }
     [[ -z "$IOT_HUB_CONNECTION_STRING" ]] && { print_error 'IoT hub connection string is required'; exit 1; }
-    [[ -z "$STORAGE_ACCOUNT_CONNECTION_STRING" ]] && { print_error 'Storage account connection string is required'; exit 1; }
+    [[ -z "$BLOB_STORE_SAS" ]] && { print_error 'Blob storage URI is required'; exit 1; }
 
     echo 'Required parameters are provided'
 }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Azure/iotedge/pull/7313 which introduces the use of short-lived SAS tokens to get an identity using the AzureCLI task. The use of shared keys to access the blob storage account is now discouraged, prompting this change.

- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
