### PR TITLE
Upgrade alpine image for building rocksdb

### DIFF
--- a/edge-util/docker/linux/Dockerfile
+++ b/edge-util/docker/linux/Dockerfile
@@ -1,7 +1,6 @@
 ﻿# syntax=docker/dockerfile:1.4
 
-# We don't need dotnet/runtime-deps, but we do need alpine. This is an easy way to get it from mcr.microsoft.com.
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine
+FROM mcr.microsoft.com/mirror/docker/library/alpine:3.14
 
 ARG num_procs=4
 ARG TARGETPLATFORM

--- a/edge-util/docker/linux/Dockerfile
+++ b/edge-util/docker/linux/Dockerfile
@@ -1,6 +1,6 @@
 ﻿# syntax=docker/dockerfile:1.4
 
-FROM alpine:3.14
+FROM alpine:3
 
 ARG num_procs=4
 ARG TARGETPLATFORM

--- a/edge-util/docker/linux/Dockerfile
+++ b/edge-util/docker/linux/Dockerfile
@@ -1,6 +1,7 @@
 ﻿# syntax=docker/dockerfile:1.4
 
-FROM alpine:3
+# We don't need dotnet/runtime-deps, but we do need alpine. This is an easy way to get it from mcr.microsoft.com.
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine
 
 ARG num_procs=4
 ARG TARGETPLATFORM


### PR DESCRIPTION
Docker has been throttling anonymous pull requests on their default docker.io registry for some time. We've avoided throttling by eliminated most of our references to base images on docker.io, but we still have one or two. Recently, one of the remaining references--the alpine image we use to build RocksDb in a container--has been getting throttled as well.

This change updates the Dockerfile we use to build RocksDb. It updates the base image to a mirrored version on mcr.microsoft.com.

To test, I ran the CI Build pipeline and confirmed that RocksDB is successfully built. I also ran the end-to-end test pipeline against the built binaries to confirm they behave as expected.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.