### PR TITLE
Fix docker-proxy startup issues

### DIFF
--- a/edgelet/contrib/snap/socat.sh
+++ b/edgelet/contrib/snap/socat.sh
@@ -1,3 +1,26 @@
 #!/bin/sh
 
-$SNAP/usr/bin/socat UNIX-LISTEN:$SNAP_COMMON/docker-proxy.sock,reuseaddr,fork,user=snap_aziotedge,group=snap_aziotedge UNIX-CONNECT:/var/run/docker.sock
+docker_socket="/var/run/docker.sock"
+timeout=30
+interval=5
+
+# Waiting before notifying makes sure that both
+# docker-proxy & aziot-edged start only after docker is
+# up and running. It's helpful on slower devices esp. after boot-up.
+for i in $(seq 0 $interval $timeout); do
+    if [ -e "$docker_socket" ]; then
+        echo "Docker socket ($docker_socket) is available."
+        break
+    fi
+
+    echo "Docker socket ($docker_socket) does not exist yet. Waiting... ($(($timeout - $i)) seconds left)"
+    sleep $interval
+done
+
+# We report that docker-proxy is ready regardless of whether the
+# socket exists or not otherwise the snap installation will fail.
+# This is a better UX as the user can now fix the issue themselves.. say
+# they installed iotedge before docker.
+systemd-notify --ready
+
+$SNAP/usr/bin/socat UNIX-LISTEN:$SNAP_COMMON/docker-proxy.sock,reuseaddr,fork,unlink-early,user=snap_aziotedge,group=snap_aziotedge UNIX-CONNECT:$docker_socket

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -114,6 +114,7 @@ apps:
       - snap/command-chain/drop-privileges.sh
     command: usr/libexec/aziot/aziot-edged
     daemon: simple
+    after: [ docker-proxy ]
     plugs:
       - docker
       - identity-service
@@ -135,11 +136,12 @@ apps:
       - run-iotedge
   docker-proxy:
     command: bin/socat.sh
-    daemon: simple
+    daemon: notify
     plugs:
       - docker
       - network
       - network-bind
+      - daemon-notify
 
 hooks:
   configure:


### PR DESCRIPTION
This is an attempt to fix the  docker proxy issues reported in #7255 using the approaches discussed there.
The issues are:
1. If `docker-proxy.sock` already exists, `socat` fails to start. I wasn't able to reproduce this, but adding `unlink-early` to the options passed to `socat`  should remove any existing file first, see [socat's man page](https://linux.die.net/man/1/socat).
> CWunlink-early
Unlinks (removes) the file before opening it and even before applying user-early etc.
2. There's a race condition where the snap starts before docker is up and running (occurs after restarts):
```
systemd[1]: Started Service for snap application azure-iot-edge.aziot-edged.
systemd[1]: Started Service for snap application azure-iot-edge.docker-proxy.
azure-iot-edge.aziot-edged[873]: Making /var/run/iotedge if it does not exist
azure-iot-edge.aziot-edged[873]: Successfully made /var/run/iotedge if it did not exist
azure-iot-edge.aziot-edged[878]: [INFO] - Starting Azure IoT Edge Daemon
azure-iot-edge.aziot-edged[878]: [INFO] - Version - 1.5.0
azure-iot-edge.aziot-edged[878]: [INFO] - Obtaining Edge device provisioning data...
azure-iot-edge.aziot-edged[878]: [INFO] - Device is core-22-test on my-iotedge-test.azure-devices.net
azure-iot-edge.aziot-edged[878]: [INFO] - Initializing module runtime...
azure-iot-edge.aziot-edged[878]: [INFO] - Using runtime network id azure-iot-edge
azure-iot-edge.docker-proxy[1029]: 2024/07/24 12:59:59 socat[1029] E connect(5, AF=1 "/var/run/docker.sock", 22): No such file or directory
azure-iot-edge.aziot-edged[878]: [WARN] - container runtime error
azure-iot-edge.aziot-edged[878]: Caused by:
azure-iot-edge.aziot-edged[878]:     0: connection error: Connection reset by peer (os error 104)
azure-iot-edge.aziot-edged[878]:     1: Connection reset by peer (os error 104)
azure-iot-edge.aziot-edged[878]: [ERR!] - Failed to initialize module runtime: runtime operation error: initialize module runtime
systemd[1]: snap.azure-iot-edge.aziot-edged.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: snap.azure-iot-edge.aziot-edged.service: Failed with result 'exit-code'.
systemd[1]: snap.azure-iot-edge.aziot-edged.service: Consumed 2.382s CPU time.
systemd[1]: snap.azure-iot-edge.aziot-edged.service: Scheduled restart job, restart counter is at 1.
systemd[1]: Stopped Service for snap application azure-iot-edge.aziot-edged.
systemd[1]: snap.azure-iot-edge.aziot-edged.service: Consumed 2.382s CPU time.
```

Now, `docker-proxy` waits until docker is ready and `aziot-edged` only starts after `docker-proxy` is ready.
I was able to reproduce this issue and the logs look like this after the fix:

```
systemd[1]: Starting Service for snap application azure-iot-edge.docker-proxy...
azure-iot-edge.docker-proxy[730]: Docker socket (/var/run/docker.sock) does not exist yet. Sleeping...
azure-iot-edge.docker-proxy[730]: Docker socket (/var/run/docker.sock) does not exist yet. Sleeping...
azure-iot-edge.docker-proxy[730]: Docker socket (/var/run/docker.sock) does not exist yet. Sleeping...
azure-iot-edge.docker-proxy[730]: Docker socket (/var/run/docker.sock) does not exist yet. Sleeping...
systemd[1]: Started Service for snap application azure-iot-edge.docker-proxy.
systemd[1]: Started Service for snap application azure-iot-edge.aziot-edged.
azure-iot-edge.aziot-edged[993]: Making /var/run/iotedge if it does not exist
azure-iot-edge.aziot-edged[993]: Successfully made /var/run/iotedge if it did not exist
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:23Z [INFO] - Starting Azure IoT Edge Daemon
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:23Z [INFO] - Version - 1.5.0
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:23Z [INFO] - Obtaining Edge device provisioning data...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Device is core-22-test on my-iotedge-test.azure-devices.net
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Initializing module runtime...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Using runtime network id azure-iot-edge
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Successfully initialized module runtime
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Using existing Edge CA certificate
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Certificate aziot-edged-ca will be auto-renewed. Next renewal at 2024-10-04T12:53:53+00:00.
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Stopping all modules...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Stopping module edgeAgent...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - All modules stopped
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Detecting if device information has changed...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Device information has not changed
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting management API...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting workload API...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting new listener for module edgeAgent
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting workload API...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Stopping listener for module edgeAgent
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Workload API stopped
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting watchdog with 60 second period...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Watchdog checking Edge runtime status
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Edge runtime status is failed, starting module now...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting module edgeAgent...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting new listener for module edgeAgent
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting workload API...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:26Z [INFO] - Starting image garbage collection task...
azure-iot-edge.aziot-edged[1006]: 2024-07-25T12:39:27Z [INFO] - Started Edge runtime module edgeAgent
```

When doing local tests, make sure you're running the snap in `devmode` (because [daemon-notify](https://snapcraft.io/docs/daemon-notify-interface) won't auto-connect currently) and the snap is connected to the identity service:

```console
$ snap install azure-iot-edge_1.5.0_amd64.snap --devmode
$ snap connect azure-iot-edge:identity-service azure-iot-identity:identity-service
$ snap connect azure-iot-edge:aziotctl-executables azure-iot-identity:aziotctl-executables
$ snap set azure-iot-edge raw-config=...
```

Follow ups:
- Please make a request to the Snap Store requesting autoconnection of the daemon-notify interface. We need it to ensure `aziot-edged` starts _after_ `docker-proxy`. A `simple` daemon can't differentiate when `docker-proxy` is running or simply sleeping.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
