### PR TITLE
Move storage URI generation to a template so agents don't need to be updated with azcli 2.x

### DIFF
--- a/builds/checkin/e2e-checkin.yaml
+++ b/builds/checkin/e2e-checkin.yaml
@@ -49,8 +49,14 @@ stages:
       builtImages: $[stageDependencies.CheckBuildImages.check_source_change_runtime.outputs['check_files.RUNTIMECHANGES']]
       builtPackages: $[stageDependencies.CheckBuildPackages.check_source_change_edgelet.outputs['check_files.EDGELETCHANGES']]
     jobs:
+      - template: ../e2e/templates/get-storage-uri.yaml
+        parameters:
+          azureSubscription: $(az.subscription)
+
       - job: ubuntu_2004_msmoby
         displayName: Ubuntu 20.04 with iotedge-moby
+        dependsOn: Token
+        condition: succeeded('Token')
         variables:
           verbose: false
           os: linux
@@ -58,8 +64,9 @@ stages:
           artifactName: iotedged-ubuntu20.04-amd64
           identityServiceArtifactName: packages_ubuntu-20.04_amd64
           identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+          sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
         steps:
         - template: ../e2e/templates/e2e-setup.yaml
         - template: ../e2e/templates/e2e-run.yaml
-
-    
+          parameters:
+            sas_uri: $(sas_uri)

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -26,10 +26,16 @@ variables:
 
 jobs:
 
+  - template: templates/get-storage-uri.yaml
+    parameters:
+      azureSubscription: $(az.subscription)
+
 ################################################################################
   - job: debian_11_arm32v7
 ################################################################################
     displayName: Debian 11 arm32v7
+    dependsOn: Token
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.custom.name)
@@ -41,6 +47,7 @@ jobs:
       artifactName: iotedged-debian11-arm32v7
       identityServiceArtifactName: packages_debian-11-slim_arm32v7
       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     timeoutInMinutes: 120
 
@@ -49,11 +56,15 @@ jobs:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: ubuntu_2004_msmoby
 ################################################################################
     displayName: Ubuntu 20.04 with iotedge-moby
+    dependsOn: Token
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.linux.name)
@@ -66,17 +77,22 @@ jobs:
       artifactName: iotedged-ubuntu20.04-amd64
       identityServiceArtifactName: packages_ubuntu-20.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     timeoutInMinutes: 90
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: ubuntu_2004_docker
 ################################################################################
     displayName: Ubuntu 20.04 with Docker (minimal)
+    dependsOn: Token
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.linux.name)
@@ -89,16 +105,22 @@ jobs:
       artifactName: iotedged-ubuntu20.04-amd64
       identityServiceArtifactName: packages_ubuntu-20.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
       minimal: true
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: ubuntu_2004_arm64v8
 ################################################################################
     displayName: Ubuntu 20.04 on arm64v8
+    dependsOn: Token
+    condition: succeeded('Token')
+
     pool:
       name: $(pool.linux.arm.name)
       demands:
@@ -110,17 +132,22 @@ jobs:
       artifactName: iotedged-ubuntu20.04-aarch64
       identityServiceArtifactName: packages_ubuntu-20.04_aarch64
       identityServicePackageFilter: aziot-identity-service_*_arm64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     timeoutInMinutes: 120
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: ubuntu_2204
 ################################################################################
     displayName: Ubuntu 22.04 on amd64
+    dependsOn: Token
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.linux.name)
@@ -133,17 +160,22 @@ jobs:
       artifactName: iotedged-ubuntu22.04-amd64
       identityServiceArtifactName: packages_ubuntu-22.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     timeoutInMinutes: 90
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: ubuntu_2204_arm64v8
 ################################################################################
     displayName: Ubuntu 22.04 on arm64v8
+    dependsOn: Token
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.linux.arm.name)
@@ -156,20 +188,26 @@ jobs:
       artifactName: iotedged-ubuntu22.04-aarch64
       identityServiceArtifactName: packages_ubuntu-22.04_aarch64
       identityServicePackageFilter: aziot-identity-service_*_arm64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     timeoutInMinutes: 90
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: snaps
 ################################################################################
     displayName: Snaps
+    dependsOn: Token
+    condition: succeeded('Token')
 
     variables:
       os: linux
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     strategy:
       matrix:
@@ -199,11 +237,15 @@ jobs:
       displayName: Install Docker as a snap
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
   ################################################################################
   - job: redhat8_amd64
   ################################################################################
     displayName: RedHat8 amd64
+    dependsOn: Token
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.linux.name)
@@ -216,15 +258,20 @@ jobs:
       artifactName: iotedged-redhat8-amd64
       identityServiceArtifactName: packages_redhat-ubi8-latest_amd64
       identityServicePackageFilter: aziot-identity-service-?.*.x86_64.rpm
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
   ################################################################################
   - job: redhat9_amd64
   ################################################################################
     displayName: RedHat9 amd64
+    dependsOn: Token
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.linux.name)
@@ -237,15 +284,20 @@ jobs:
       artifactName: iotedged-redhat9-amd64
       identityServiceArtifactName: packages_redhat-ubi9-latest_amd64
       identityServicePackageFilter: aziot-identity-service-?.*.x86_64.rpm
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: linux_amd64_proxy
 ################################################################################
     displayName: Linux amd64 behind a proxy
+    dependsOn: Token
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.custom.name)
@@ -257,6 +309,7 @@ jobs:
       artifactName: iotedged-ubuntu20.04-amd64
       identityServiceArtifactName: packages_ubuntu-20.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
       # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
       'agent.disablelogplugin.testfilepublisherplugin': true
       'agent.disablelogplugin.testresultlogplugin': true
@@ -274,12 +327,14 @@ jobs:
     - template: templates/e2e-run.yaml
       parameters:
         test_type: http_proxy
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: mariner2_amd64
 ################################################################################
     displayName: Mariner 2.0 amd64
-    condition: eq(variables['run.EFLOW.amd64'], true)
+    dependsOn: Token
+    condition: and(succeeded(), eq(variables['run.EFLOW.amd64'], 'true'))
     pool:
       name: $(pool.linux.name)
       demands:
@@ -291,18 +346,22 @@ jobs:
       artifactName: iotedged-mariner2-amd64
       identityServiceArtifactName: packages_mariner-2_amd64
       identityServicePackageFilter: aziot-identity-service-?.*.cm2.x86_64.rpm
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     timeoutInMinutes: 90
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
 
 ################################################################################
   - job: mariner2_arm64
 ################################################################################
     displayName: Mariner 2.0 arm64
-    condition: eq(variables['run.EFLOW.arm64'], true)
+    dependsOn: Token
+    condition: and(succeeded(), eq(variables['run.EFLOW.amd64'], 'true'))
     pool:
       name: $(pool.linux.arm.name)
       demands:
@@ -312,9 +371,12 @@ jobs:
       os: linux
       arch: amd64
       artifactName: iotedged-mariner2-aarch64
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     timeoutInMinutes: 90
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -72,7 +72,7 @@ steps:
     E2E_IOT_HUB_CONNECTION_STRING: ${{ parameters['IotHubConnectionString'] }}
     E2E_REGISTRIES__0__PASSWORD: $(TestContainerRegistryPassword)
     E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
-    E2E_BLOB_STORE_SAS: $(TestBlobStoreSas)
+    E2E_BLOB_STORE_SAS: $(sas_uri)
     no_proxy: 'localhost'
 
 - task: PublishTestResults@2

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -2,6 +2,7 @@ parameters:
   EventHubCompatibleEndpoint: '$(TestEventHubCompatibleEndpoint)'
   IotHubConnectionString: '$(TestIotHubConnectionString)'
   test_type: ''
+  sas_uri: ''
 
 steps:
 # This E2E test pipeline uses the following filters in order to skip certain tests:
@@ -72,7 +73,7 @@ steps:
     E2E_IOT_HUB_CONNECTION_STRING: ${{ parameters['IotHubConnectionString'] }}
     E2E_REGISTRIES__0__PASSWORD: $(TestContainerRegistryPassword)
     E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
-    E2E_BLOB_STORE_SAS: $(sas_uri)
+    E2E_BLOB_STORE_SAS: ${{ parameters['sas_uri'] }} 
     no_proxy: 'localhost'
 
 - task: PublishTestResults@2

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -84,38 +84,6 @@ steps:
       downloadType: single
       artifactName: $(artifactName)
       allowPartiallySucceededBuilds: true
-
-  - task: AzureCLI@2
-    displayName: 'Get SAS URI for Blob Storage Account'
-    inputs:
-      azureSubscription: $(az.subscription)
-      scriptType: 'bash'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        # Hardcoded resource group and storage account name
-        resource_group="EdgeBuilds"
-        storage_account="e2eteststorageedge"
-
-        # Set container name with name of storage account container
-        container_name="e2etest"
-
-        # Set expiry time for the SAS token
-        expiry_time=$(date --utc --date "+2 days" +"%Y-%m-%dT%H:%MZ")
-
-        # Generate the SAS token for the container
-        sasToken=$(az storage container generate-sas --account-name "$storage_account" --name "$container_name" --https-only --expiry "$expiry_time" --as-user --auth-mode login --permissions drwl --output tsv)
-        if [ $? -ne 0 ]; then
-          echo "Failed to generate SAS token."
-          exit 1
-        fi
-
-        echo "SAS token for Azure Storage account acquired.  Expires $expiry_time"
-
-        # Construct the SAS URI
-        endpoint=$(az storage account show --name "$storage_account" --resource-group "$resource_group" --query 'primaryEndpoints.blob' -o tsv)
-        sasUri="$endpoint$container_name?$sasToken"
-
-        echo "##vso[task.setvariable variable=TestBlobStoreSas;issecret=true]$sasUri"
   
   - task: PowerShell@2
     displayName: 'Download aziot-identity-service'
@@ -210,7 +178,6 @@ steps:
         loadGenImage = "$imagePrefix-load-gen:$imageTag";
         relayerImage = "$imagePrefix-relayer:$imageTag";
         networkControllerImage = "$imagePrefix-network-controller:$imageTag";
-        testBlobStoreSas = $TestBlobStoreSas;
         testResultCoordinatorImage = "$imagePrefix-test-result-coordinator:$imageTag";
         metricsCollectorImage = "$imagePrefix-metrics-collector:$imageTag";
         iotHubResourceId = "$env:IOT_HUB_RESOURCE_ID";

--- a/builds/e2e/templates/get-storage-uri.yaml
+++ b/builds/e2e/templates/get-storage-uri.yaml
@@ -1,0 +1,34 @@
+# get-sas-uri.yaml
+parameters:
+    azureSubscription: ''
+
+jobs:
+  - job: Token
+    displayName: 'Get SAS URI for Blob Storage Account'
+    steps:
+      - task: AzureCLI@2
+        name: generate
+        displayName: 'Get Storage URI'
+        inputs:
+          azureSubscription: ${{ parameters.azureSubscription }}
+          scriptType: 'bash'
+          scriptLocation: 'inlineScript'
+          inlineScript: |
+            # Hardcoded resource group and storage account name
+            resource_group="EdgeBuilds"
+            storage_account="e2eteststorageedge"
+            # Set container name with name of storage account container
+            container_name="e2etest"
+            # Set expiry time for the SAS token
+            expiry_time=$(date --utc --date "+2 days" +"%Y-%m-%dT%H:%MZ")
+            # Generate the SAS token for the container
+            sasToken=$(az storage container generate-sas --account-name "$storage_account" --name "$container_name" --https-only --expiry "$expiry_time" --as-user --auth-mode login --permissions drwl --output tsv)
+            if [ $? -ne 0 ]; then
+              echo "Failed to generate SAS token."
+              exit 1
+            fi
+            echo "SAS token for Azure Storage account acquired.  Expires $expiry_time"
+            # Construct the SAS URI
+            endpoint=$(az storage account show --name "$storage_account" --resource-group "$resource_group" --query 'primaryEndpoints.blob' -o tsv)
+            sas_uri="$endpoint$container_name?$sasToken"
+            echo "##vso[task.setvariable variable=sas_uri;issecret=true;isoutput=true]$sas_uri"


### PR DESCRIPTION
As fallout from changes introduced by https://github.com/Azure/iotedge/pull/7309, the internal Core E2E tests pipeline was broken with the following error:

![image](https://github.com/user-attachments/assets/82939f53-f036-46be-b32a-fd6cd5933c92)


This PR fixes that pipeline by pulling out the storage URI generation into a template and by generating the URI only once and passing it to all the platforms.

For testing, I ran the checkin pipeline and the core E2E pipeline against these changes and the pipelines passed.


- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
