### PR TITLE
Add token support to nested E2E

### DIFF
--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -47,12 +47,16 @@ stages:
 - stage: RunNestedTests
   dependsOn: LockAgents
   jobs:
+  - template: templates/get-storage-uri.yaml
+    parameters:
+      azureSubscription: $(az.subscription)
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
       upstream.protocol: mqtt
       test.l4DeploymentFileName: 'nestededge_middleLayerBaseDeployment_mqtt.json'
   - job:  SetupVM_and_RunTest_level3
     dependsOn:
+      - Token
       - SetupVM_level5_mqtt
       - SetupVM_level4_mqtt
     displayName: Set up and run tests
@@ -68,6 +72,7 @@ stages:
       artifactName: iotedged-ubuntu20.04-amd64
       identityServiceArtifactName: packages_ubuntu-20.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
       nestededge: true
     pool:
       name: $(pool.name)
@@ -88,6 +93,7 @@ stages:
           EventHubCompatibleEndpoint: '$(IotHub-EventHubConnStr)'
           IotHubConnectionString: '$(IotHub-ConnStr)'
           test_type: nestededge_mqtt
+          sas_uri: $(sas_uri)
       - template: templates/nested-deploy-config.yaml
         parameters:
           deviceId: $(lvl5DeviceId)
@@ -107,6 +113,7 @@ stages:
           EventHubCompatibleEndpoint: '$(IotHub-EventHubConnStr)'
           IotHubConnectionString: '$(IotHub-ConnStr)'
           test_type: nestededge_amqp
+          sas_uri: $(sas_uri)
 
 - stage: Cleanup
   condition: always()


### PR DESCRIPTION
This PR introduces the use of short-lived SAS tokens to get an identity using the AzureCLI task. The use of shared keys to access the blob storage account is now discouraged, prompting this change.

This is the manually triggered test run for this PR: 

![image](https://github.com/user-attachments/assets/ea144456-4375-4126-8826-db31f470d4a6)



- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).