### PR TITLE
Install snaps with devmode in end-to-end tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 SupportedPackageExtension.Snap => new[]
                 {
                     "set -e",
-                    $"snap install {string.Join(' ', packages)} --dangerous",
+                    $"snap install {string.Join(' ', packages)} --dangerous --devmode",
                     "snap connect azure-iot-identity:hostname-control",
                     "snap connect azure-iot-identity:log-observe",
                     "snap connect azure-iot-identity:mount-observe",


### PR DESCRIPTION
Following a recent fix in our snap packages, our end-to-end tests started to fail. The tests need to install the azure-iot-edge snap with --devmode, at least until we get approval to auto-connect the daemon-notify interface (in progress).

This change updates the install command in the end-to-end tests to prevent failures. I ran the end-to-end test pipeline and confirmed this fixes the failures.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.