### PR TITLE
Allow independent enable/disable of mariner builds

### DIFF
--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -170,7 +170,7 @@ stages:
       - job: mariner_linux
     ################################################################################
         displayName: Mariner_Linux
-        condition: or(eq(variables['build.linux.mariner'], ''), eq(variables['build.linux.mariner'], true))
+        condition: or(eq(variables['build.mariner.amd64'], ''), eq(variables['build.mariner.amd64'], true))
         pool:
           name: $(pool.linux.name)
           demands:
@@ -254,7 +254,7 @@ stages:
       - job: mariner_linux_arm64
     ################################################################################
         displayName: Mariner_Linux on ARM64
-        condition: or(eq(variables['build.linux.mariner'], ''), eq(variables['build.linux.mariner'], true))
+        condition: or(eq(variables['build.mariner.arm64'], ''), eq(variables['build.mariner.arm64'], true))
         timeoutInMinutes: 90
         pool:
           name: $(pool.linux.arm.name)


### PR DESCRIPTION
We can disable package builds for Mariner (amd64 and arm64) with a pipeline variable. We want to disable them independently (e.g., build amd64 but disable arm64). This change updates the pipeline template that handles mariner builds. The new variables are `build.mariner.amd64` and `build.mariner.arm64`.

I ran the ci-build and e2e-checkin pipelines with `build.mariner.amd64=true, build.mariner.arm64=false` and confirmed that the arm64 build was skipped.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.