### PR TITLE
Fix end-to-end test failures on Raspberry Pi

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
             // Trim potential whitespaces and double quotes
             char[] trimChr = { ' ', '"' };
             os = os.Split('=').Last().Trim(trimChr).ToLower();
+            os = os == "raspbian" ? "debian" : os;
             // Split potential version description (in case VERSION_ID was not available, the VERSION line can contain e.g. '7 (Core)')
             version = version.Split('=').Last().Split(' ').First().Trim(trimChr);
 


### PR DESCRIPTION
A recent change updated the some logic in the end-to-end tests to match the main branch, but an important detail was missed. The result is that end-to-end tests fail on Raspberry Pi in the release/1.4 branch because the tests don't recognize the device's operating system. This change corrects that problem.

I confirmed that the tests pass on Raspberry Pi with this change.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.