### PR TITLE
Fix snap startup error

### DIFF
--- a/edgelet/contrib/snap/socat.sh
+++ b/edgelet/contrib/snap/socat.sh
@@ -21,6 +21,6 @@ done
 # socket exists or not otherwise the snap installation will fail.
 # This is a better UX as the user can now fix the issue themselves.. say
 # they installed iotedge before docker.
-systemd-notify --ready
-
-$SNAP/usr/bin/socat UNIX-LISTEN:$SNAP_COMMON/docker-proxy.sock,reuseaddr,fork,unlink-early,user=snap_aziotedge,group=snap_aziotedge UNIX-CONNECT:$docker_socket
+exec systemd-notify --exec --ready \; $SNAP/usr/bin/socat \
+    UNIX-LISTEN:$SNAP_COMMON/docker-proxy.sock,reuseaddr,fork,unlink-early,user=snap_aziotedge,group=snap_aziotedge \
+    UNIX-CONNECT:$docker_socket

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -22,12 +22,6 @@ mkdir -p /etc/aziot/edged/config.d
 snapctl get raw-config > /etc/aziot/config.toml
 
 {
-	toml_kvp "hostname" "$(hostnamectl hostname)"
-} | tee /etc/aziot/keyd/config.d/01-snap.toml /etc/aziot/certd/config.d/01-snap.toml /etc/aziot/identityd/config.d/01-snap.toml /etc/aziot/tpmd/config.d/01-snap.toml
-
-{
-	toml_kvp "hostname" "$(hostnamectl hostname)"
-
 	toml_new_section "agent"
 	toml_kvp "name" "edgeAgent"
 	toml_kvp "type" "docker"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: azure-iot-edge
-base: core22 # the base snap is the execution environment for this snap
+base: core24 # the base snap is the execution environment for this snap
 summary: Managed solution for deploying and configuring software on IoT devices
 description: |
   Azure IoT Edge is a fully managed service that delivers cloud intelligence
@@ -16,8 +16,8 @@ system-usernames:
 package-repositories:
   - type: apt
     components: [ main ]
-    suites: [ jammy ]
-    url: https://packages.microsoft.com/ubuntu/22.04/prod
+    suites: [ noble ]
+    url: https://packages.microsoft.com/ubuntu/24.04/prod
     key-id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
 
 parts:


### PR DESCRIPTION
Cherry-pick d950b624e62063f2458dd1a9ca64371f73d8a045.

To test, I built new snaps in the CI build pipeline, ran the end-to-end tests pipeline against them, and confirmed the snap jobs pass. Since the snap jobs install with --devmode, I also published to a temporary branch in the marketplace and tested manually.