### PR TITLE
Add support for Ubuntu 24.04

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -293,9 +293,8 @@ jobs:
     condition: succeeded('Token')
 
     pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
+      name: $(pool.custom.name)
+      demands: ubuntu2404-amd64-e2e-tests
 
     variables:
       os: linux

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -319,7 +319,7 @@ jobs:
 ################################################################################
     displayName: Ubuntu 24.04 on arm64v8
     dependsOn: Token
-    condition: and(false, succeeded('Token'))
+    condition: succeeded('Token')
 
     pool:
       name: $(pool.custom.name)

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -15,8 +15,8 @@ variables:
   Codeql.Enabled: false
   DisableDockerDetector: true
   # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
-  # environments that are very similar to other platforms/environments in our matrix, Ubuntu 20.04
-  # with the 'docker-ce' package vs. Ubuntu 20.04 with the 'iotedge-moby' package vs. the same
+  # environments that are very similar to other platforms/environments in our matrix, e.g., Ubuntu
+  # 20.04 with the 'docker-ce' package vs. Ubuntu 20.04 with the 'iotedge-moby' package vs. the same
   # variations in Ubuntu 22.04. In these instances the platforms/environments are so similar that we
   # don't reasonably expect to encounter differences--if we do, it would likely manifest during
   # installation, or in running a very basic test. We don't need to repeat the entire test suite.
@@ -274,6 +274,62 @@ jobs:
       arch: arm64v8
       artifactName: iotedged-ubuntu22.04-aarch64
       identityServiceArtifactName: packages_ubuntu-22.04_aarch64
+      identityServicePackageFilter: aziot-identity-service_*_arm64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
+
+    timeoutInMinutes: 90
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
+
+################################################################################
+  - job: ubuntu_2404
+################################################################################
+    displayName: Ubuntu 24.04 on amd64
+    dependsOn: Token
+    condition: succeeded('Token')
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu24.04-amd64
+      identityServiceArtifactName: packages_ubuntu-24.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
+
+    timeoutInMinutes: 90
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+      parameters:
+        sas_uri: $(sas_uri)
+
+################################################################################
+  - job: ubuntu_2404_arm64v8
+################################################################################
+    displayName: Ubuntu 24.04 on arm64v8
+    dependsOn: Token
+    condition: succeeded('Token')
+
+    pool:
+      name: $(pool.linux.arm.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-24.04-arm64-msmoby
+
+    variables:
+      os: linux
+      arch: arm64v8
+      artifactName: iotedged-ubuntu24.04-aarch64
+      identityServiceArtifactName: packages_ubuntu-24.04_aarch64
       identityServicePackageFilter: aziot-identity-service_*_arm64.deb
       sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -320,9 +320,8 @@ jobs:
     condition: succeeded('Token')
 
     pool:
-      name: $(pool.linux.arm.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-24.04-arm64-msmoby
+      name: $(pool.custom.name)
+      demands: ubuntu2404-arm64-e2e-tests
 
     variables:
       os: linux

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -319,7 +319,7 @@ jobs:
 ################################################################################
     displayName: Ubuntu 24.04 on arm64v8
     dependsOn: Token
-    condition: succeeded('Token')
+    condition: and(false, succeeded('Token'))
 
     pool:
       name: $(pool.custom.name)

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -307,7 +307,9 @@ jobs:
     timeoutInMinutes: 90
 
     steps:
+    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
       parameters:
         sas_uri: $(sas_uri)
@@ -334,7 +336,9 @@ jobs:
     timeoutInMinutes: 90
 
     steps:
+    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
       parameters:
         sas_uri: $(sas_uri)

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -22,8 +22,8 @@ variables:
   Codeql.Enabled: false
   DisableDockerDetector: true
   # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
-  # environments that are very similar to other platforms/environments in our matrix, Ubuntu 20.04
-  # with the 'docker-ce' package vs. Ubuntu 20.04 with the 'iotedge-moby' package vs. the same
+  # environments that are very similar to other platforms/environments in our matrix, e.g., Ubuntu
+  # 20.04 with the 'docker-ce' package vs. Ubuntu 20.04 with the 'iotedge-moby' package vs. the same
   # variations in Ubuntu 22.04. In these instances the platforms/environments are so similar that we
   # don't reasonably expect to encounter differences--if we do, it would likely manifest during
   # installation, or in running a very basic test. We don't need to repeat the entire test suite.

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -107,6 +107,18 @@ stages:
               arch: aarch64
               os: ubuntu22.04
               target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+            Ubuntu2404-amd64:
+              arch: amd64
+              os: ubuntu24.04
+              target.iotedged: edgelet/target/release
+            Ubuntu2404-arm32v7:
+              arch: arm32v7
+              os: ubuntu24.04
+              target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+            Ubuntu2404-aarch64:
+              arch: aarch64
+              os: ubuntu24.04
+              target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
         steps:
           - bash: |
               BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`

--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "serde",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "http-common",
  "libc",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "pkcs11",
  "serde",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "http-common",
  "serde",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "async-trait",
  "chrono",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "serde",
  "toml",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -1500,7 +1500,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "env_logger",
  "log",
@@ -1647,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "cc",
 ]
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1758,7 +1758,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 
 [[package]]
 name = "pkg-config"
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8daa5cd4adb81dfd72ef7eced624ec4a906913f2"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/build/linux/package.sh
+++ b/edgelet/build/linux/package.sh
@@ -66,6 +66,10 @@ case "$PACKAGE_OS" in
     'ubuntu22.04')
         DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/ubuntu:22.04'
         ;;
+    
+    'ubuntu24.04')
+        DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/ubuntu:24.04'
+        ;;
 esac
 
 if [ -z "$DOCKER_IMAGE" ]; then
@@ -170,7 +174,7 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
         '
         ;;
 
-    ubuntu20.04.amd64|ubuntu22.04.amd64)
+    ubuntu20.04.amd64|ubuntu22.04.amd64|ubuntu24.04.amd64)
         packages='binutils build-essential ca-certificates curl debhelper file git make gcc g++ \
             libcurl4-openssl-dev libssl-dev pkg-config uuid-dev'
         case "$PACKAGE_OS" in
@@ -190,7 +194,7 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
         "
         ;;
 
-    ubuntu20.04.arm32v7|ubuntu22.04.arm32v7)
+    ubuntu20.04.arm32v7|ubuntu22.04.arm32v7|ubuntu24.04.arm32v7)
         packages='binutils build-essential ca-certificates curl debhelper file git make gcc g++ \
             gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libcurl4-openssl-dev:armhf \
             libssl-dev:armhf uuid-dev:armhf'
@@ -227,7 +231,7 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
         "
         ;;
 
-    ubuntu20.04.aarch64|ubuntu22.04.aarch64)
+    ubuntu20.04.aarch64|ubuntu22.04.aarch64|ubuntu24.04.aarch64)
         packages='binutils build-essential ca-certificates curl debhelper file git make gcc \
             g++ gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libcurl4-openssl-dev:arm64 \
             libssl-dev:arm64 uuid-dev:arm64'

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -13,7 +13,7 @@ There are two options for building the IoT Edge Security Daemon.
 
 Linux packages are built using the `edgelet/build/linux/package.sh` script. Set the following environment variables, then invoke the script:
 
-1. `PACKAGE_OS`: This is the OS on which the resulting packages will be installed. It should be one of `redhat8`, `redhat9`, `debian11`, `debian12`, `ubuntu20.04`, or `ubuntu22.04`.
+1. `PACKAGE_OS`: This is the OS on which the resulting packages will be installed. It should be one of `redhat8`, `redhat9`, `debian11`, `debian12`, `ubuntu20.04`, `ubuntu22.04`, or `ubuntu24.04`.
 
 1. `PACKAGE_ARCH`: This is the architecture of the OS on which the resulting packages will be installed. It should be one of `amd64`, `arm32v7` or `aarch64`.
 
@@ -87,7 +87,7 @@ apt-get install \
     libcurl4-openssl-dev libssl-dev uuid-dev
 ```
 
-#### Ubuntu 22.04
+#### Ubuntu 22.04/24.04
 
 ```sh
 apt-get update

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
             switch (os)
             {
                 case "ubuntu":
-                    if (version != "20.04" && version != "22.04")
+                    if (version != "20.04" && version != "22.04" && version != "24.04")
                     {
                         ThrowUnsupportedOs();
                     }
 
-                    // if we find .deb and .snap files on an Ubuntu 22.04 host, prefer snap
-                    packageExtension = detectedSnap && version == "22.04"
+                    // if we find .deb and .snap files on an Ubuntu host, prefer snap
+                    packageExtension = detectedSnap
                         ? SupportedPackageExtension.Snap
                         : SupportedPackageExtension.Deb;
                     break;


### PR DESCRIPTION
This change updates the build and tests pipelines to support Ubuntu 24.04 amd64 and arm64v8. Specifically,
- Add Ubuntu 24.04 amd64 and arm64v8 jobs to the end-to-end tests pipeline.
- Update iot-identity-service repo references in Cargo.lock so we pick up the right packages in the end-to-end tests.
- Add Ubuntu 24.04 amd64 and arm64v8 to the packages build pipeline and related scripts.
- Update markdown docs and comments as needed.
- Update end-to-end test code to support Ubuntu 24.04 packages.

To test, I ran the CI Build and end-to-end test pipelines and confirmed they pass.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.