### PR TITLE
Increase dockerd client timeout from 30s to 60s.

### DIFF
--- a/edgelet/docker-rs/src/apis/client.rs
+++ b/edgelet/docker-rs/src/apis/client.rs
@@ -249,7 +249,7 @@ macro_rules! api_call {
                 let request = api_call!(@inner build_request builder $(body $btype)?)?;
 
                 let response = ::tokio::time::timeout(
-                    ::std::time::Duration::from_secs(30),
+                    ::std::time::Duration::from_secs(60),
                     self.client.request(request)
                 )
                 .await??;


### PR DESCRIPTION
When edged sends an image pull request to dockerd, it expects dockerd to respond with the HTTP response status code and headers within 30s. The image pull itself does not need to complete within those 30s, just the initial start of the HTTP response, after which dockerd streams JSON events in the response to indicate the pull progress.

We have one customer whose device is unable to pull module images from their remote container registry. This is because dockerd needs to check whether the image exists on the ACR before it sends the HTTP response status code, and this check itself takes ~45s or so. When edged times out and abandons the request after 30s, dockerd has different behavior depending on whether the image tag is `latest` or not:

- If the image tag is `latest`, dockerd continues to pull the image in the background even after edged cancels the request. So one would think that when the image is pulled eventually, the next request to pull the image would succeed immediately. However the semantics of the `latest` tag are that dockerd must still check the ACR to see if there's a newer image available, and this also ends up taking ~45s, so the net effect is that edged continues to time out the request.

- If the image tag is not `latest`, dockerd also stops pulling the image after edged cancels the request, instead of continuing to pull it in the background. So every attempt to pull the image is canceled and the image never gets pulled to the device.

So this change increases the timeout of requests to dockerd to 60s.

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
