### PR TITLE
Upgrade go to 1.21 for Mariner toolkit

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "serde",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "http-common",
  "libc",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "pkcs11",
  "serde",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "http-common",
  "serde",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "serde",
  "toml",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -1500,7 +1500,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "env_logger",
  "log",
@@ -1647,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "cc",
 ]
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1758,7 +1758,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 
 [[package]]
 name = "pkg-config"
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#0de6f8079ad94e7367a1e8d52364d047099a63fa"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#061e4c98bf02b38633a2881c0be789b5244454fd"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -36,10 +36,10 @@ apt-get update -y
 apt-get install -y \
     cmake curl gcc g++ git jq make pkg-config \
     libclang1 libssl-dev llvm-dev \
-    cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+    cpio genisoimage golang-1.21-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
 rm -f /usr/bin/go
-ln -vs /usr/lib/go-1.20/bin/go /usr/bin/go
+ln -vs /usr/lib/go-1.21/bin/go /usr/bin/go
 if [ -f /.dockerenv ]; then
     mv /.dockerenv /.dockerenv.old
 fi


### PR DESCRIPTION
Mariner builds recently started failing because the Mariner toolkit upgraded its go dependency requirement to 1.21. This change updates go in Mariner builds.

To test, I ran the CI Build pipeline and confirmed that Mariner builds pass.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.