### PR TITLE
Enable 1ES agent for Ubuntu 24.04 x64 end-to-end tests

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -293,8 +293,9 @@ jobs:
     condition: succeeded('Token')
 
     pool:
-      name: $(pool.custom.name)
-      demands: ubuntu2404-amd64-e2e-tests
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
 
     variables:
       os: linux


### PR DESCRIPTION
1ES has added support for Ubuntu 24.04 x64, so we no longer need to use a custom agent. This change updates the end-to-end test pipeline to use a 1ES-hosted agent.

I ran the end-to-end tests against this PR and confirmed that the Ubuntu 24.04 x64 job runs on a 1ES-hosted agent and passes.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.