### PR TITLE
Remove unnecessary steps from Ubuntu 24.04 end-to-end job

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -308,9 +308,7 @@ jobs:
     timeoutInMinutes: 90
 
     steps:
-    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
       parameters:
         sas_uri: $(sas_uri)


### PR DESCRIPTION
A recent PR converted the Ubuntu 24.04 x64 end-to-end test job to use an ephemeral 1ES-hosted agent instead of a stateful custom agent. With this conversion, we should have removed steps from the job that are only needed for stateful agents, but it was missed. This update removes the steps.

I ran the end-to-end test pipeline against this PR and confirmed that the steps are removed and the job still passes.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.