### PR TITLE
Upgrade deprecated pipeline tasks

### DIFF
--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -82,10 +82,9 @@ jobs:
         -reporttypes:"Cobertura"
     displayName: Generate coverage report
     condition: succeededOrFailed()
-  - task: PublishCodeCoverageResults@1
+  - task: PublishCodeCoverageResults@2
     displayName: Publish coverage report
     inputs:
-      codeCoverageTool: Cobertura
       summaryFileLocation: '$(Build.SourcesDirectory)/Cobertura.xml'
     condition: succeededOrFailed()
   - task: BuildQualityChecks@8

--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -57,7 +57,7 @@ jobs:
   dependsOn: check_run_pipeline
   condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
   variables:
-    coverage.goal: 50
+    coverage.goal: 58
   pool:
     name: $(pool.linux.name)
     demands:
@@ -92,6 +92,6 @@ jobs:
     inputs:
       checkCoverage: true
       coverageFailOption: fixed
-      coverageType: branch
+      coverageType: lines
       coverageThreshold: $(coverage.goal)
     condition: succeededOrFailed()

--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -87,7 +87,7 @@ jobs:
     inputs:
       summaryFileLocation: '$(Build.SourcesDirectory)/Cobertura.xml'
     condition: succeededOrFailed()
-  - task: BuildQualityChecks@8
+  - task: BuildQualityChecks@9
     displayName: 'Check build quality'
     inputs:
       checkCoverage: true

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -21,7 +21,7 @@ jobs:
     variables:
       testEnvironment: linux
     steps:
-      - task: AzureKeyVault@1
+      - task: AzureKeyVault@2
         displayName: Get secrets
         inputs:
           azureSubscription: $(azure.subscription)

--- a/builds/e2e/compare-compatibility.yaml
+++ b/builds/e2e/compare-compatibility.yaml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - template: templates/e2e-setup.yaml
-    - task: AzureKeyVault@1
+    - task: AzureKeyVault@2
       displayName: 'Get Secret'
       inputs:
         azureSubscription: $(az.subscription)
@@ -108,7 +108,7 @@ jobs:
     - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-clear-docker-cached-images.yaml
-    - task: AzureKeyVault@1
+    - task: AzureKeyVault@2
       displayName: 'Get Secret'
       inputs:
         azureSubscription: $(az.subscription)
@@ -177,7 +177,7 @@ jobs:
     timeoutInMinutes: 180
 
     steps:
-    - task: AzureKeyVault@1
+    - task: AzureKeyVault@2
       displayName: 'Get Secret'
       inputs:
         azureSubscription: $(az.subscription)

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -120,7 +120,7 @@ jobs:
         fetchDepth: 100
         submodules: recursive
         condition: and(succeeded(), eq(variables['run.flag'], 1))
-      - task: AzureKeyVault@1
+      - task: AzureKeyVault@2
         condition: eq(variables['run.flag'], 1)
         displayName: 'Azure Key Vault: EdgeBuildkv'
         inputs:
@@ -132,7 +132,7 @@ jobs:
             kvLogAnalyticWorkspaceId,
             kvLogAnalyticSharedKey,
             GitHubAccessToken
-      - task: AzureKeyVault@1
+      - task: AzureKeyVault@2
         displayName: 'Azure Key Vault: $(azure.keyVault)'
         inputs:
           azureSubscription: $(azure.subscription)
@@ -314,7 +314,7 @@ jobs:
         fetchDepth: 100
         submodules: recursive
         condition: and(succeeded(), eq(variables['run.flag'], 1))
-      - task: AzureKeyVault@1
+      - task: AzureKeyVault@2
         condition: eq(variables['run.flag'], 1)
         displayName: 'Azure Key Vault: EdgeBuildkv'
         inputs:
@@ -326,7 +326,7 @@ jobs:
             kvLogAnalyticWorkspaceId,
             kvLogAnalyticSharedKey,
             GitHubAccessToken
-      - task: AzureKeyVault@1
+      - task: AzureKeyVault@2
         displayName: 'Azure Key Vault: $(azure.keyVault)'
         inputs:
           azureSubscription: $(azure.subscription)

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -4,7 +4,7 @@ steps:
     fetchDepth: 100
     submodules: recursive
   
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: Get secrets
     inputs:
       azureSubscription: $(az.subscription)

--- a/builds/e2e/templates/longhaul-setup.yaml
+++ b/builds/e2e/templates/longhaul-setup.yaml
@@ -16,7 +16,7 @@ steps:
     clean: true
     fetchDepth: 100
     submodules: recursive
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Azure Key Vault: EdgeBuildkv'
     inputs:
       azureSubscription: $(azure.subscription)
@@ -30,7 +30,7 @@ steps:
         kvLogAnalyticSharedKey,
         EdgeLonghaulStorageAccountConnString,
         GitHubAccessToken
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Azure Key Vault: $(azure.keyVault)'
     inputs:
       azureSubscription: $(azure.subscription)

--- a/builds/e2e/templates/nested-get-secrets.yaml
+++ b/builds/e2e/templates/nested-get-secrets.yaml
@@ -1,5 +1,5 @@
 steps:
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Azure Key Vault: EdgeBuildkv'
     condition: or(eq(variables['run.flag'], ''), eq(variables['run.flag'], 1))
     inputs:
@@ -15,7 +15,7 @@ steps:
         GitHubAccessToken,
         edgebuild-service-principal-secret,
 
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Azure Key Vault: $(azure.keyVault)'
     inputs:
       azureSubscription: $(az.subscription)

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -224,7 +224,7 @@ stages:
               fi
               echo "##vso[task.setvariable variable=MARINER_ARCH;]$mariner_arch"
             displayName: Set Version
-          - task: AzureKeyVault@1
+          - task: AzureKeyVault@2
             displayName: 'Azure Key Vault: EdgeBuildkv'
             inputs:
               azureSubscription: $(az.subscription)

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -23,7 +23,7 @@ steps:
 - checkout: self
   fetchDepth: 1
 
-- task: AzureKeyVault@1
+- task: AzureKeyVault@2
   displayName: Get secrets
   inputs:
     azureSubscription: $(az.subscription)


### PR DESCRIPTION
The AzureKeyVault@1 and PublishCodeCoverageResults@1 tasks for Azure pipelines are deprecated. This change updates both tasks in YAML files across the codebase. It also updates the BuildQualityChecks task to the latest version.

I confirmed that deprecation warnings disappear from the affected pipelines.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.