### PR TITLE
Check `aziot-edge` component instead of `aziot-identity-service`

### DIFF
--- a/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
+++ b/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
@@ -185,7 +185,7 @@ impl AziotEdgedVersion {
                 .flat_map(|channel| channel.products.iter())
                 .filter(|product| product.id == "aziot-edge")
                 .flat_map(|product| product.components.iter())
-                .filter(|component| component.name == "aziot-identity-service")
+                .filter(|component| component.name == "aziot-edge")
                 .map(|component| component.version.clone())
                 .collect();
             let parsed_versions = versions


### PR DESCRIPTION
Bugfix `iotedge check` where IoTEdge uses the version of aziot-identity-service as aziot-edge version which results in 
```
‼ aziot-edge package is up-to-date - Warning
Installed IoT Edge daemon has version 1.5.10 but 1.5.3 is the latest stable version available.
```
even if the latest version of IoT Edge daemon is installed on the machine.

Root cause:

The IoTEdge queries
https://github.com/Azure/azure-iotedge/blob/main/product-versions.json
for the latest info on each of the component. Currently, IoTEdge parses the wrong `component` instead of getting the version of `aziot-edge`, it gets `aziot-identity-service` version. The aziot-identity-service version is then compared against the 
aziot-edge installed version if it is the latest version.


Manual test with custom build ID: 
<img width="856" alt="image" src="https://github.com/user-attachments/assets/d2314a5a-eadc-4c3c-886b-468e1b13ca79">

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
