### PR TITLE
Fix error message in 'iotedge check'

### DIFF
--- a/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
+++ b/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
@@ -199,7 +199,7 @@ impl AziotEdgedVersion {
                 .find(|semver| semver.major == actual_semver.major && semver.minor == actual_semver.minor)
                 .ok_or_else(|| {
                     anyhow!(
-                        "could not find aziot-identity-service version {}.{}.x in list of supported products at {}",
+                        "could not find aziot-edge version {}.{}.x in list of supported products at {}",
                         actual_semver.major,
                         actual_semver.minor,
                         Self::URI


### PR DESCRIPTION
A recent update (ca5b8af2152e181c438f304ee9bd1fb5e0f546fc) to `iotedge check` code fixed the way we calculate the expected current version of aziot-edged. This change makes the corresponding update to an error message in that part of the code.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.