### PR TITLE
Remove schedule triggers for release/1.4

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -11,18 +11,6 @@ schedules:
     include:
     - main
   always: true
-- cron: "0 0 * * 1"
-  displayName: Weekly run release/1.4
-  branches:
-    include:
-    - release/1.4
-  always: true
-- cron: "0 0 * * 2"
-  displayName: Weekly run release/1.1
-  branches:
-    include:
-    - release/1.1
-  always: true
 
 variables:
   Codeql.Enabled: false

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -10,12 +10,6 @@ schedules:
     include:
     - main
   always: true
-- cron: "0 12 * * *"
-  displayName: Daily run release/1.4
-  branches:
-    include:
-    - release/1.4
-  always: true
 
 variables:
   Codeql.Enabled: false

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -1,12 +1,5 @@
 trigger: none
 pr: none
-schedules:
-- cron: "0 23 * * 4"
-  displayName: Weekly run Thursday night
-  branches:
-    include:
-    - release/1.4
-  always: true
 
 variables:
   Codeql.Enabled: false

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -11,12 +11,6 @@ schedules:
     include:
     - main
   always: true
-- cron: "0 0 * * 4"
-  displayName: Weekly run release/1.4
-  branches:
-    include:
-    - release/1.4
-  always: true
 
 variables:
   Codeql.Enabled: false

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -1,12 +1,5 @@
 trigger: none
 pr: none
-schedules:
-- cron: "0 23 * * 4"
-  displayName: Weekly run Thursday night
-  branches:
-    include:
-    - release/1.4
-  always: true
 
 variables:
   Codeql.Enabled: false

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -8,7 +8,6 @@ schedules:
   branches:
     include:
     - main
-    - release/*
   always: true
 
 resources:

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -2,13 +2,6 @@
 
 pr: none
 trigger: none
-schedules:
-- cron: '0 3 * * *'
-  displayName: Nightly run 1.4 LTS
-  branches:
-    include:
-    - release/1.4
-  always: true
 
 variables:
   Codeql.Enabled: false


### PR DESCRIPTION
v1.4 LTS is EOL on November 12, 2024. This change removes any scheduled triggers for pipelines in the release/1.4 branch so they won't continue to run after the EOL date.

Other trigger types to consider:
- PR triggers won't be disabled. The core team won't be filing PRs against the release/1.4 branch after the EOL date, and if they did, it's not a big deal if a pipeline or two run (and potentially fail). PRs from the community don't trigger pipelines without an approver from the core team.
- CI triggers don't need to be disabled. Instead, we'll make the branch read-only so that no changes can be pushed.
- There are no pipelines in the release/1.4 branch that declare pipeline completion triggers.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.