### PR TITLE
Avoid container build by adding /.mariner-toolkit-ignore-dockerenv

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -74,7 +74,7 @@ jobs:
         displayName: Set Version
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
-      - script: "cargo install cross --version ^0.2" --locked
+      - script: "cargo install cross --version ^0.2 --locked"
         displayName: "Install cross"
       - script: "cross build --target armv7-unknown-linux-gnueabihf"
         displayName: armv7-unknown-linux-gnueabihf build
@@ -105,7 +105,7 @@ jobs:
         displayName: Set Version
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
-      - script: "cargo install cross --version ^0.2" --locked
+      - script: "cargo install cross --version ^0.2 --locked"
         displayName: "Install cross"
       - script: "cross build --target aarch64-unknown-linux-gnu"
         displayName: aarch64-unknown-linux-gnu build

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -74,7 +74,7 @@ jobs:
         displayName: Set Version
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
-      - script: "cargo install cross --version ^0.2"
+      - script: "cargo install cross --version ^0.2" --locked
         displayName: "Install cross"
       - script: "cross build --target armv7-unknown-linux-gnueabihf"
         displayName: armv7-unknown-linux-gnueabihf build
@@ -105,7 +105,7 @@ jobs:
         displayName: Set Version
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
-      - script: "cargo install cross --version ^0.2"
+      - script: "cargo install cross --version ^0.2" --locked
         displayName: "Install cross"
       - script: "cross build --target aarch64-unknown-linux-gnu"
         displayName: aarch64-unknown-linux-gnu build

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -173,11 +173,18 @@ stages:
           - script: |
               #!/bin/bash
               set -xeuo pipefail
+              snap list
               sudo snap install snapcraft --classic
-              LXD=$(command -v lxd)
+              snap list
+              getent group lxd
+              groups
               sudo usermod -a -G lxd $USER
+              groups
+              getent group lxd
               /usr/bin/newgrp lxd <<EONG
-              $LXD init --minimal
+              set -xeuo pipefail
+              groups
+              lxd init --minimal
               SNAPCRAFT_BUILD_INFO=1 snapcraft --use-lxd
               EONG
             displayName: Build snap

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -174,19 +174,14 @@ stages:
               #!/bin/bash
               set -xeuo pipefail
               snap list
+              sudo snap refresh
+              snap list
               sudo snap install snapcraft --classic
               snap list
               getent group lxd
               groups
-              sudo usermod -a -G lxd $USER
-              groups
-              getent group lxd
-              /usr/bin/newgrp lxd <<EONG
-              set -xeuo pipefail
-              groups
               lxd init --minimal
               SNAPCRAFT_BUILD_INFO=1 snapcraft --use-lxd
-              EONG
             displayName: Build snap
             condition: eq(${{ parameters['E2EBuild'] }}, false)
           - task: CopyFiles@2

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -173,11 +173,11 @@ stages:
           - script: |
               #!/bin/bash
               set -xeuo pipefail
-              command -v lxd
               sudo snap install snapcraft --classic
+              LXD=$(command -v lxd)
               sudo usermod -a -G lxd $USER
               /usr/bin/newgrp lxd <<EONG
-              lxd init --minimal
+              $LXD init --minimal
               SNAPCRAFT_BUILD_INFO=1 snapcraft --use-lxd
               EONG
             displayName: Build snap

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -173,13 +173,8 @@ stages:
           - script: |
               #!/bin/bash
               set -xeuo pipefail
-              snap list
               sudo snap refresh
-              snap list
               sudo snap install snapcraft --classic
-              snap list
-              getent group lxd
-              groups
               lxd init --minimal
               SNAPCRAFT_BUILD_INFO=1 snapcraft --use-lxd
             displayName: Build snap

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -171,9 +171,15 @@ stages:
           - ImageOverride -equals $(image)
         steps:
           - script: |
+              #!/bin/bash
+              set -xeuo pipefail
+              command -v lxd
               sudo snap install snapcraft --classic
+              sudo usermod -a -G lxd $USER
+              /usr/bin/newgrp lxd <<EONG
               lxd init --minimal
               SNAPCRAFT_BUILD_INFO=1 snapcraft --use-lxd
+              EONG
             displayName: Build snap
             condition: eq(${{ parameters['E2EBuild'] }}, false)
           - task: CopyFiles@2

--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "serde",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "http-common",
  "libc",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "pkcs11",
  "serde",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "http-common",
  "serde",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "serde",
  "toml",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -1500,7 +1500,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "env_logger",
  "log",
@@ -1647,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "cc",
 ]
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1758,7 +1758,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 
 [[package]]
 name = "pkg-config"
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2a8d851ae0d0a1a95903bbc3071f1c75887b2314"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#5e642260fec24f182f807a2451f3c2fefd8256bf"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -40,9 +40,7 @@ apt-get install -y \
 
 rm -f /usr/bin/go
 ln -vs /usr/lib/go-1.21/bin/go /usr/bin/go
-if [ -f /.dockerenv ]; then
-    mv /.dockerenv /.dockerenv.old
-fi
+touch /.mariner-toolkit-ignore-dockerenv
 
 # Download Mariner repo and build toolkit
 mkdir -p ${MARINER_BUILD_ROOT}


### PR DESCRIPTION
Our Azure Linux builds started failing in the past week or so because Azure Linux recently made a change to how they detect container builds (see https://github.com/microsoft/azurelinux/pull/11135), so the trick we employed to force a regular build (even though we're building in a container) stopped working. This change removes the trick and takes the recommended approach of adding `/.mariner-toolkit-ignore-dockerenv` to the container.

Other changes were also needed to resolve problems that came up while testing this PR:
- Snap builds began failing, seemingly due to a bad version combination of snapcraft and lxd. I updated the build task to do `snap refresh` before building.
- Our CI build for Azure Linux on arm64 uses the build scripts from the iot-identity-service repo, so I updated this repo's references to the iot-identity-service repo to fix the container build detection problem there.
- A recent update to a dependency of cross requires a newer rustc version and was causing the edgelet CI runs to fail in this PR because our rustc version is fixed at 1.73, I added the '--locked' flag to the cargo command that installs cross in the edgelet CI build.

To test, I confirmed that the CI Build passes with these changes.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.