### PR TITLE
Consolidate Mariner build jobs into a single matrix

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -488,8 +488,6 @@ jobs:
       os: linux
       arch: amd64
       artifactName: iotedged-mariner2-amd64
-      identityServiceArtifactName: packages_mariner-2_amd64
-      identityServicePackageFilter: aziot-identity-service-?.*.cm2.x86_64.rpm
       sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
 
     timeoutInMinutes: 90

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -363,8 +363,6 @@ jobs:
         parameters:
           edgelet.artifact.name: 'iotedged-mariner2-amd64'
           images.artifact.name: '$(images.artifact.name.linux)'
-          aziotis.artifact.name: 'packages_mariner-2_amd64'
-          aziotis.package.filter: 'aziot-identity-service-?.*.x86_64.rpm'
           identityServiceArtifactName: packages_mariner-2_amd64
           quickstart.artifactName: 'IotEdgeQuickstart.linux-x64.tar.gz'
       - task: DeleteFiles@1

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -87,7 +87,7 @@ steps:
   
   - task: PowerShell@2
     displayName: 'Download aziot-identity-service'
-    condition: not(contains(variables['artifactName'], 'mariner2-aarch64'))
+    condition: not(contains(variables['artifactName'], 'mariner'))
     inputs:
       filePath: $(Build.SourcesDirectory)/scripts/local/test/DownloadIdentityService.ps1
       workingDirectory: $(Build.SourcesDirectory)
@@ -97,6 +97,7 @@ steps:
       PACKAGE_FILTER: $(identityServicePackageFilter)
       DOWNLOAD_PATH: $(System.ArtifactsDirectory)/$(artifactName)
       IDENTITY_SERVICE_COMMIT: $(aziotis.commit)
+  
   - pwsh: |
       $certsDir = '$(System.ArtifactsDirectory)/certs'
       New-Item "$certsDir" -ItemType Directory -Force | Out-Null

--- a/builds/e2e/templates/longhaul-setup.yaml
+++ b/builds/e2e/templates/longhaul-setup.yaml
@@ -70,6 +70,7 @@ steps:
         $(images.artifact.name.linux)/CACertificates/openssl_root_ca.cnf
   - task: PowerShell@2
     displayName: 'Download aziot-identity-service'
+    condition: not(contains(variables['artifactName'], 'mariner'))
     inputs:
       filePath: $(Build.StagingDirectory)/$(images.artifact.name.linux)/scripts/local/test/DownloadIdentityService.ps1
     env:
@@ -90,6 +91,7 @@ steps:
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
   - task: CopyFiles@2
     displayName: 'Copy aziot-identity-service'
+    condition: not(contains(variables['artifactName'], 'mariner'))
     inputs:
       SourceFolder: "$(Build.StagingDirectory)"
       Contents: "${{ parameters['aziotis.package.filter'] }}"

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -196,109 +196,35 @@ stages:
     ################################################################################
       - job: mariner_linux
     ################################################################################
-        displayName: Mariner_Linux
+        displayName: Mariner Linux
         condition: or(eq(variables['build.linux.mariner'], ''), eq(variables['build.linux.mariner'], true))
-        pool:
-          name: $(pool.linux.name)
-          demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
-          - DiskSizeGiB -equals 100 # EFLOW requires ~85GB to build the edgelet artifacts
-          - WorkFolder -equals /mnt/storage/_work
+        timeoutInMinutes: 90
         strategy:
           matrix:
-            CBL-Mariner2.0-amd64:
+            2.0-amd64:
+              agent-pool: $(pool.linux.name)
+              agent-image: agent-aziotedge-ubuntu-20.04-docker
               arch: amd64
               os: mariner
               os_version: 2
               mariner_release: 2.0-stable
               target.iotedged: builds/mariner2/out/RPMS
               target.logs: builds/mariner2/build/logs/pkggen/rpmbuilding/
-        steps:
-          - bash: |
-              BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
-              VERSION="$BASE_VERSION~$BUILD_BUILDNUMBER"
-              echo "##vso[task.setvariable variable=VERSION;]$VERSION"
-              echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
-              echo "PACKAGE_OS=$(os)"
-              echo "##vso[task.setvariable variable=MARINER_RELEASE;]$(mariner_release)"
-              mariner_arch=$(arch)
-              if [ $mariner_arch == "amd64" ]; then
-                mariner_arch="x86_64"
-              fi
-              echo "##vso[task.setvariable variable=MARINER_ARCH;]$mariner_arch"
-            displayName: Set Version
-          - task: AzureKeyVault@2
-            displayName: 'Azure Key Vault: EdgeBuildkv'
-            inputs:
-              azureSubscription: $(az.subscription)
-              KeyVaultName: 'edgebuildkv'
-              SecretsFilter: >-
-                IotEdge1-GitHub-PAT
-          - task: PowerShell@2
-            displayName: 'Download aziot-identity-service'
-            inputs:
-              filePath: scripts/local/test/DownloadIdentityService.ps1
-            env:
-              GITHUB_TOKEN: $(IotEdge1-GitHub-PAT)
-              ARTIFACT_NAME: 'packages_$(os)-$(os_version)_$(arch)'
-              PACKAGE_FILTER: 'aziot-identity-service-*.cm$(os_version).$(MARINER_ARCH).rpm'
-              DOWNLOAD_PATH: $(Build.SourcesDirectory)
-          - bash: |
-              docker run --rm \
-                -v "$(Build.SourcesDirectory):/src" \
-                -e "ARCH=$arch" \
-                -e "OS=$OS" \
-                -e "MARINER_RELEASE=$MARINER_RELEASE" \
-                -e "MARINER_ARCH=$MARINER_ARCH" \
-                -e "VERSION=$VERSION" \
-                --privileged \
-                'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04' \
-                '/src/edgelet/build/linux/package-mariner.sh'
-          - task: CopyFiles@2
-            displayName: Copy iotedged build logs to artifact staging
-            inputs:
-              SourceFolder: $(target.logs)
-              Contents: |
-                **/*.rpm.log
-              TargetFolder: '$(build.artifactstagingdirectory)'
-            condition: succeededOrFailed()
-          - task: CopyFiles@2
-            displayName: Copy iotedged Files to Artifact Staging
-            inputs:
-              SourceFolder: $(target.iotedged)/$(mariner_arch)
-              Contents: |
-                aziot-edge-*.rpm
-              TargetFolder: '$(build.artifactstagingdirectory)'
-            condition: succeededOrFailed()
-          - task: PublishBuildArtifacts@1
-            displayName: Publish Artifacts
-            inputs:
-              PathtoPublish: '$(build.artifactstagingdirectory)'
-              ArtifactName: 'iotedged-$(os)$(os_version)-$(arch)'
-            condition: succeededOrFailed()
-
-    ################################################################################
-      - job: mariner_linux_arm64
-    ################################################################################
-        displayName: Mariner_Linux on ARM64
-        condition: or(eq(variables['build.linux.mariner'], ''), eq(variables['build.linux.mariner'], true))
-        timeoutInMinutes: 90
-        pool:
-          name: $(pool.linux.arm.name)
-          demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
-          - DiskSizeGiB -equals 100 # EFLOW requires ~85GB to build the edgelet artifacts
-          - WorkFolder -equals /mnt/storage/_work
-        strategy:
-          matrix:
-            CBL-Mariner2.0-aarch64:
+            2.0-aarch64:
+              agent-pool: $(pool.linux.arm.name)
+              agent-image: agent-aziotedge-ubuntu-20.04-arm64-docker
               arch: aarch64
               os: mariner
               os_version: 2
               mariner_release: 2.0-stable
               target.iotedged: builds/mariner2/out/RPMS
               target.logs: builds/mariner2/build/logs/pkggen/rpmbuilding/
-
+        pool:
+          name: $(agent-pool)
+          demands:
+          - ImageOverride -equals $(agent-image)
+          - DiskSizeGiB -equals 100 # EFLOW requires ~85GB to build the edgelet artifacts
+          - WorkFolder -equals /mnt/storage/_work
         steps:
           - bash: |
               BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
@@ -314,32 +240,24 @@ stages:
               fi
               echo "##vso[task.setvariable variable=MARINER_ARCH;]$mariner_arch"
             displayName: Set Version
-
-          # remove this one 1ES can prevent the daily update from triggering
-          - bash: |
-              set -ex
-              ps aux | grep -i apt
-              waitAttempts=120
-              sleepDuration=10
-              for (( i=0; $i<$waitAttempts; i++ ))
-              do
-                if [[ $(ps aux | grep -c apt.systemd.daily) == 1 ]]; then
-                  break
-                fi
-                sleep $sleepDuration
-              done
-              ps aux | grep -i apt
-            displayName: Wait for 1ES agent update
-
-          - bash: |
-              sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
-              curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-              sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu `lsb_release -cs` stable"
-              sudo apt update
-              sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
-              sudo systemctl restart docker
-            displayName: Install moby
-
+          - task: AzureKeyVault@2
+            displayName: 'Get secret to download aziot-identity-service (amd64 only)'
+            condition: and(succeeded(), eq('$(arch)','amd64'))
+            inputs:
+              azureSubscription: $(az.subscription)
+              KeyVaultName: 'edgebuildkv'
+              SecretsFilter: >-
+                IotEdge1-GitHub-PAT
+          - task: PowerShell@2
+            displayName: 'Download aziot-identity-service (amd64 only)'
+            condition: and(succeeded(), eq('$(arch)','amd64'))
+            inputs:
+              filePath: scripts/local/test/DownloadIdentityService.ps1
+            env:
+              GITHUB_TOKEN: $(IotEdge1-GitHub-PAT)
+              ARTIFACT_NAME: 'packages_$(os)-$(os_version)_$(arch)'
+              PACKAGE_FILTER: 'aziot-identity-service-*.cm$(os_version).$(MARINER_ARCH).rpm'
+              DOWNLOAD_PATH: $(Build.SourcesDirectory)
           # build iot-identity-service here since they cannot build native aarch64 packages
           - bash: |
               set -ex
@@ -351,7 +269,7 @@ stages:
                 | tr -d "'" \
                 | tr -d '"'
               )
-              sudo docker run --rm \
+              docker run --rm \
                 -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
                 -e "ARCH=$PACKAGE_ARCH" \
                 -e "OS=$OS:$OSVERSION" \
@@ -361,12 +279,13 @@ stages:
                 'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04' \
                 '/src/ci/package.sh'
               popd
-              sudo cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-$packageVersion-1.cm$(os_version).$(arch).rpm .
-              sudo cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-debuginfo-$packageVersion-1.cm$(os_version).$(arch).rpm .
-              sudo rm -rf iot-identity-service
-
+              cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-$packageVersion-1.cm$(os_version).$(arch).rpm .
+              cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-debuginfo-$packageVersion-1.cm$(os_version).$(arch).rpm .
+              rm -rf iot-identity-service
+            displayName: Build iot-identity-service (aarch64 only)
+            condition: and(succeeded(), eq('$(arch)','aarch64'))
           - bash: |
-              sudo docker run --rm \
+              docker run --rm \
                 -v "$(Build.SourcesDirectory):/src" \
                 -e "ARCH=$arch" \
                 -e "OS=$OS" \
@@ -376,6 +295,7 @@ stages:
                 --privileged \
                 'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04' \
                 '/src/edgelet/build/linux/package-mariner.sh'
+            displayName: Build aziot-edge
           - task: CopyFiles@2
             displayName: Copy iotedged build logs to artifact staging
             inputs:
@@ -389,7 +309,7 @@ stages:
             inputs:
               SourceFolder: $(target.iotedged)/$(mariner_arch)
               Contents: |
-                *.rpm
+                aziot-edge-*.rpm
               TargetFolder: '$(build.artifactstagingdirectory)'
             condition: succeededOrFailed()
           - task: PublishBuildArtifacts@1

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -272,7 +272,7 @@ stages:
               SourceFolder: iot-identity-service/Mariner-Build/build/logs/pkggen/rpmbuilding
               Contents: |
                 **/*.rpm.log
-              TargetFolder: '$(build.artifactstagingdirectory)/aziot-identity'
+              TargetFolder: '$(build.artifactstagingdirectory)'
             condition: succeededOrFailed()
           - task: CopyFiles@2
             displayName: Copy aziot-identity packages to artifact staging
@@ -281,13 +281,7 @@ stages:
               Contents: |
                 *.rpm
                 !*-devel-*.rpm
-              TargetFolder: '$(build.artifactstagingdirectory)/aziot-identity'
-            condition: succeededOrFailed()
-          - task: PublishBuildArtifacts@1
-            displayName: Publish aziot-identity artifacts
-            inputs:
-              PathtoPublish: '$(build.artifactstagingdirectory)/aziot-identity'
-              ArtifactName: 'aziot-identity-$(os)$(os_version)-$(arch)'
+              TargetFolder: '$(build.artifactstagingdirectory)'
             condition: succeededOrFailed()
           - bash: sudo rm -rf iot-identity-service
             displayName: Clean up iot-identity-service

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -242,7 +242,7 @@ stages:
             displayName: Set Version
           - task: AzureKeyVault@2
             displayName: 'Get secret to download aziot-identity-service (amd64 only)'
-            condition: and(succeeded(), eq('$(arch)','amd64'))
+            condition: and(succeeded(), eq(variables.arch,'amd64'))
             inputs:
               azureSubscription: $(az.subscription)
               KeyVaultName: 'edgebuildkv'
@@ -250,7 +250,7 @@ stages:
                 IotEdge1-GitHub-PAT
           - task: PowerShell@2
             displayName: 'Download aziot-identity-service (amd64 only)'
-            condition: and(succeeded(), eq('$(arch)','amd64'))
+            condition: and(succeeded(), eq(variables.arch,'amd64'))
             inputs:
               filePath: scripts/local/test/DownloadIdentityService.ps1
             env:
@@ -283,7 +283,7 @@ stages:
               cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-debuginfo-$packageVersion-1.cm$(os_version).$(arch).rpm .
               rm -rf iot-identity-service
             displayName: Build iot-identity-service (aarch64 only)
-            condition: and(succeeded(), eq('$(arch)','aarch64'))
+            condition: and(succeeded(), eq(variables.arch,'aarch64'))
           - bash: |
               docker run --rm \
                 -v "$(Build.SourcesDirectory):/src" \

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -297,14 +297,14 @@ stages:
                 --privileged \
                 'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04' \
                 '/src/edgelet/build/linux/package-mariner.sh'
-            displayName: Build aziot-edge
+            displayName: Create aziot-edge packages
           - task: CopyFiles@2
-            displayName: Copy iotedged build logs to artifact staging
+            displayName: Copy aziot-edge build logs to artifact staging
             inputs:
               SourceFolder: builds/mariner2/build/logs/pkggen/rpmbuilding
               Contents: |
                 **/*.rpm.log
-              TargetFolder: '$(build.artifactstagingdirectory)/iotedged'
+              TargetFolder: '$(build.artifactstagingdirectory)'
             condition: succeededOrFailed()
           - task: CopyFiles@2
             displayName: Copy aziot-edge packages to artifact staging
@@ -312,11 +312,11 @@ stages:
               SourceFolder: $(target.iotedged)
               Contents: |
                 aziot-edge-*.rpm
-              TargetFolder: '$(build.artifactstagingdirectory)/iotedged'
+              TargetFolder: '$(build.artifactstagingdirectory)'
             condition: succeededOrFailed()
           - task: PublishBuildArtifacts@1
-            displayName: Publish Artifacts
+            displayName: Publish artifacts
             inputs:
-              PathtoPublish: '$(build.artifactstagingdirectory)/iotedged'
+              PathtoPublish: '$(build.artifactstagingdirectory)'
               ArtifactName: 'iotedged-$(os)$(os_version)-$(arch)'
             condition: succeededOrFailed()

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -246,13 +246,16 @@ stages:
                   's/^source = "git\+https:\/\/github\.com\/Azure\/iot-identity-service\?branch=main#([0-9a-fA-F]+)"$/\1/p' \
                   edgelet/Cargo.lock | head -n 1
               )
-              packageVersion=$(
-                sed -nE 's/^Depends:.*aziot-identity-service \(= (.*)-1\).*$/\1/p' edgelet/contrib/debian/control
-              )
               git clone https://github.com/Azure/iot-identity-service.git
               pushd iot-identity-service
               git checkout "$identity_commit"
               git submodule update --init --recursive .
+              packageVersion=$(
+                grep "PACKAGE_VERSION:" .github/workflows/packages.yaml \
+                | awk '{print $2}' \
+                | tr -d "'" \
+                | tr -d '"'
+              )
               docker run --rm \
                 -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
                 -e "ARCH=$PACKAGE_ARCH" \

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -208,8 +208,8 @@ stages:
               os: mariner
               os_version: 2
               mariner_release: 2.0-stable
-              target.iotedged: builds/mariner2/out/RPMS
-              target.logs: builds/mariner2/build/logs/pkggen/rpmbuilding/
+              target.identity: iot-identity-service/packages/mariner2/amd64
+              target.iotedged: builds/mariner2/out/RPMS/x86_64
             2.0-aarch64:
               agent-pool: $(pool.linux.arm.name)
               agent-image: agent-aziotedge-ubuntu-20.04-arm64-docker
@@ -217,8 +217,8 @@ stages:
               os: mariner
               os_version: 2
               mariner_release: 2.0-stable
-              target.iotedged: builds/mariner2/out/RPMS
-              target.logs: builds/mariner2/build/logs/pkggen/rpmbuilding/
+              target.identity: iot-identity-service/packages/mariner2/aarch64
+              target.iotedged: builds/mariner2/out/RPMS/aarch64
         pool:
           name: $(agent-pool)
           demands:
@@ -232,7 +232,6 @@ stages:
               echo "##vso[task.setvariable variable=VERSION;]$VERSION"
               echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
               echo "PACKAGE_OS=$(os)"
-              echo "##vso[task.setvariable variable=MARINER_RELEASE;]$(mariner_release)"
               echo "##vso[task.setvariable variable=OSVERSION;]$(os_version)"
               mariner_arch=$(arch)
               if [ $mariner_arch == "amd64" ]; then
@@ -240,35 +239,20 @@ stages:
               fi
               echo "##vso[task.setvariable variable=MARINER_ARCH;]$mariner_arch"
             displayName: Set Version
-          - task: AzureKeyVault@2
-            displayName: 'Get secret to download aziot-identity-service (amd64 only)'
-            condition: and(succeeded(), eq(variables.arch,'amd64'))
-            inputs:
-              azureSubscription: $(az.subscription)
-              KeyVaultName: 'edgebuildkv'
-              SecretsFilter: >-
-                IotEdge1-GitHub-PAT
-          - task: PowerShell@2
-            displayName: 'Download aziot-identity-service (amd64 only)'
-            condition: and(succeeded(), eq(variables.arch,'amd64'))
-            inputs:
-              filePath: scripts/local/test/DownloadIdentityService.ps1
-            env:
-              GITHUB_TOKEN: $(IotEdge1-GitHub-PAT)
-              ARTIFACT_NAME: 'packages_$(os)-$(os_version)_$(arch)'
-              PACKAGE_FILTER: 'aziot-identity-service-*.cm$(os_version).$(MARINER_ARCH).rpm'
-              DOWNLOAD_PATH: $(Build.SourcesDirectory)
-          # build iot-identity-service here since they cannot build native aarch64 packages
           - bash: |
-              set -ex
-              git clone --recurse-submodules --branch main https://github.com/Azure/iot-identity-service.git
-              pushd iot-identity-service
-              packageVersion=$(
-                grep "PACKAGE_VERSION:" .github/workflows/packages.yaml \
-                | awk '{print $2}' \
-                | tr -d "'" \
-                | tr -d '"'
+              set -xeuo pipefail
+              identity_commit=$(
+                sed -nE \
+                  's/^source = "git\+https:\/\/github\.com\/Azure\/iot-identity-service\?branch=main#([0-9a-fA-F]+)"$/\1/p' \
+                  edgelet/Cargo.lock | head -n 1
               )
+              packageVersion=$(
+                sed -nE 's/^Depends:.*aziot-identity-service \(= (.*)-1\).*$/\1/p' edgelet/contrib/debian/control
+              )
+              git clone https://github.com/Azure/iot-identity-service.git
+              pushd iot-identity-service
+              git checkout "$identity_commit"
+              git submodule update --init --recursive .
               docker run --rm \
                 -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
                 -e "ARCH=$PACKAGE_ARCH" \
@@ -279,11 +263,35 @@ stages:
                 'mcr.microsoft.com/mirror/docker/library/ubuntu:22.04' \
                 '/src/ci/package.sh'
               popd
-              cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-$packageVersion-1.cm$(os_version).$(arch).rpm .
-              cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-debuginfo-$packageVersion-1.cm$(os_version).$(arch).rpm .
-              sudo rm -rf iot-identity-service
-            displayName: Build iot-identity-service (aarch64 only)
-            condition: and(succeeded(), eq(variables.arch,'aarch64'))
+              # aziot-edge package script expects to query the version from the identity package in the root source directory
+              sudo cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-$packageVersion-1.cm$(os_version).$(MARINER_ARCH).rpm .
+            displayName: Create aziot-identity packages
+          - task: CopyFiles@2
+            displayName: Copy aziot-identity build logs to artifact staging
+            inputs:
+              SourceFolder: iot-identity-service/Mariner-Build/build/logs/pkggen/rpmbuilding
+              Contents: |
+                **/*.rpm.log
+              TargetFolder: '$(build.artifactstagingdirectory)/aziot-identity'
+            condition: succeededOrFailed()
+          - task: CopyFiles@2
+            displayName: Copy aziot-identity packages to artifact staging
+            inputs:
+              SourceFolder: $(target.identity)
+              Contents: |
+                *.rpm
+                !*-devel-*.rpm
+              TargetFolder: '$(build.artifactstagingdirectory)/aziot-identity'
+            condition: succeededOrFailed()
+          - task: PublishBuildArtifacts@1
+            displayName: Publish aziot-identity artifacts
+            inputs:
+              PathtoPublish: '$(build.artifactstagingdirectory)/aziot-identity'
+              ArtifactName: 'aziot-identity-$(os)$(os_version)-$(arch)'
+            condition: succeededOrFailed()
+          - bash: sudo rm -rf iot-identity-service
+            displayName: Clean up iot-identity-service
+            condition: succeededOrFailed()
           - bash: |
               docker run --rm \
                 -v "$(Build.SourcesDirectory):/src" \
@@ -299,22 +307,22 @@ stages:
           - task: CopyFiles@2
             displayName: Copy iotedged build logs to artifact staging
             inputs:
-              SourceFolder: $(target.logs)
+              SourceFolder: builds/mariner2/build/logs/pkggen/rpmbuilding
               Contents: |
                 **/*.rpm.log
-              TargetFolder: '$(build.artifactstagingdirectory)'
+              TargetFolder: '$(build.artifactstagingdirectory)/iotedged'
             condition: succeededOrFailed()
           - task: CopyFiles@2
-            displayName: Copy iotedged Files to Artifact Staging
+            displayName: Copy aziot-edge packages to artifact staging
             inputs:
-              SourceFolder: $(target.iotedged)/$(mariner_arch)
+              SourceFolder: $(target.iotedged)
               Contents: |
                 aziot-edge-*.rpm
-              TargetFolder: '$(build.artifactstagingdirectory)'
+              TargetFolder: '$(build.artifactstagingdirectory)/iotedged'
             condition: succeededOrFailed()
           - task: PublishBuildArtifacts@1
             displayName: Publish Artifacts
             inputs:
-              PathtoPublish: '$(build.artifactstagingdirectory)'
+              PathtoPublish: '$(build.artifactstagingdirectory)/iotedged'
               ArtifactName: 'iotedged-$(os)$(os_version)-$(arch)'
             condition: succeededOrFailed()

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -281,7 +281,7 @@ stages:
               popd
               cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-$packageVersion-1.cm$(os_version).$(arch).rpm .
               cp iot-identity-service/packages/mariner$(os_version)/$(arch)/aziot-identity-service-debuginfo-$packageVersion-1.cm$(os_version).$(arch).rpm .
-              rm -rf iot-identity-service
+              sudo rm -rf iot-identity-service
             displayName: Build iot-identity-service (aarch64 only)
             condition: and(succeeded(), eq(variables.arch,'aarch64'))
           - bash: |


### PR DESCRIPTION
In the packages build pipeline we have separate build jobs with a lot of duplicated YAML for building Mariner 2.0 amd64 vs. arm64. This change consolidates the separate jobs into a single matrix job. Note this also means we're now building identity service for amd64, not just arm64, for consistency (and because we'll eventually build identity service in this pipeline for all platforms, not just Mariner). This change should put us in a better position when we add support for Mariner 3.0 soon.

Additionally, this change fixes a bug: for Mariner arm64 we were already building the identity service bits but were always building them from the head of the main branch, even though the iotedge repo might be expecting bits built from an older commit. This change syncs the identity repo to the right commit first before building.

To test I ran the CI Build pipeline, confirmed it passes, and confirmed that the right artifacts are being produced. I also ran the End-to-end test pipeline using the bits from my CI build, and confirmed that the Mariner job uses the freshly-built identity service bits when it installs IoT Edge, and all tests pass.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.