### PR TITLE
Fix hard-coded timestamp in unit tests

### DIFF
--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TokenHelper.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TokenHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Common
     public static class TokenHelper
     {
         public static string CreateSasToken(string resourceUri, string key = null, bool expired = false) =>
-            CreateSasToken(resourceUri, expired ? new DateTime(2010, 1, 1) : new DateTime(2025, 1, 1), key);
+            CreateSasToken(resourceUri, expired ? new DateTime(2010, 1, 1) : DateTime.Now.AddYears(1), key);
 
         public static string CreateSasToken(string resourceUri, DateTime expiryTime, string key = null)
         {


### PR DESCRIPTION
Several unit tests started failing after the new year due to a hard-coded timestamp that was supposed to represent a valid future time, but is now in the past. This change updates the test code to generate a timestamp that is one year in the future relative to DateTime.Now. I confirmed the unit tests pass once more.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.