### PR TITLE
Fix: Enhance JSON Deserialization Security - Mitigate TypeNameHandling Vulnerability

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/AgentTestsBase.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/AgentTestsBase.cs
@@ -38,10 +38,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Integration.Test
 
             string testConfigPath = Path.Combine(TestConfigBasePath, testConfig);
             string json = File.ReadAllText(testConfigPath);
+            var knownTypesList = new List<Type>
+            {
+                typeof(ModulePriorityValidator)
+            };
             var settings = new JsonSerializerSettings()
             {
                 TypeNameHandling = TypeNameHandling.Auto,
-                SerializationBinder = new TypeNameSerializationBinder(format),
+                SerializationBinder = new TypeNameSerializationBinder(format, knownTypesList),
                 Converters = new List<JsonConverter>
                 {
                     new ModuleSetJsonConverter(),
@@ -253,7 +257,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Integration.Test
 
                 this.settings = new JsonSerializerSettings()
                 {
-                    TypeNameHandling = TypeNameHandling.Auto,
+                    TypeNameHandling = TypeNameHandling.None, // Security: $type is not used in json, enforcing explicit type control.
                     Converters = new List<JsonConverter>
                     {
                         new TypeSpecificJsonConverter(deserializerTypes)
@@ -313,7 +317,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Integration.Test
 
                 this.settings = new JsonSerializerSettings()
                 {
-                    TypeNameHandling = TypeNameHandling.Auto,
+                    TypeNameHandling = TypeNameHandling.None, // Security: $type is not used in json, enforcing explicit type control.
                     Converters = new List<JsonConverter>
                     {
                         new TypeSpecificJsonConverter(deserializerTypes)

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TypeNameSerializationBinder.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TypeNameSerializationBinder.cs
@@ -2,6 +2,8 @@
 namespace Microsoft.Azure.Devices.Edge.Util.Test.Common
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json.Serialization;
 
     /// <summary>
@@ -13,9 +15,21 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Common
     {
         public readonly string TypeFormat;
 
+        // KnownTypes provides a whitelist of allowed types for deserialization, mitigating potential security vulnerabilities
+        // associated with uncontrolled type deserialization when using TypeNameHandling
+        // Secure Deserialization Best Practices: https://liquid.microsoft.com/Web/Object/Read/MS.Security/Requirements/Microsoft.Security.SystemsADM.10010#Zguide
+        // CodeQL Scanning Tool Warning: https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM02211#Zguide
+        public IList<Type> KnownTypes { get; set; }
+
         public TypeNameSerializationBinder(string typeFormat)
         {
             this.TypeFormat = typeFormat;
+        }
+
+        public TypeNameSerializationBinder(string typeFormat, IList<Type> knownTypes)
+        {
+            this.TypeFormat = typeFormat;
+            this.KnownTypes = knownTypes;
         }
 
         public void BindToName(Type serializedType, out string assemblyName, out string typeName)
@@ -26,7 +40,8 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Common
 
         public Type BindToType(string assemblyName, string typeName)
         {
-            return Type.GetType(string.Format(this.TypeFormat, typeName), true);
+            Type resolvedType = Type.GetType(string.Format(this.TypeFormat, typeName), true);
+            return this.KnownTypes.SingleOrDefault(t => t == resolvedType );
         }
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TypeNameSerializationBinder.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TypeNameSerializationBinder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Common
     {
         public readonly string TypeFormat;
 
-        // KnownTypes provides a whitelist of allowed types for deserialization, mitigating potential security vulnerabilities
+        // KnownTypes provides a allow-list of allowed types for deserialization, mitigating potential security vulnerabilities
         // associated with uncontrolled type deserialization when using TypeNameHandling
         // Secure Deserialization Best Practices: https://liquid.microsoft.com/Web/Object/Read/MS.Security/Requirements/Microsoft.Security.SystemsADM.10010#Zguide
         // CodeQL Scanning Tool Warning: https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM02211#Zguide


### PR DESCRIPTION
[Bug 30973440](https://msazure.visualstudio.com/One/_workitems/edit/30973440) and [Bug 30973442](https://msazure.visualstudio.com/One/_workitems/edit/30973442)
CodeQL issue: https://liquid.microsoft.com/codeql/issues/621b3860-9992-462a-8a9d-0a24593f51a5?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058

This commit addresses a potential security vulnerability **within our test code and infrastructure** related to JSON deserialization by enhancing the type handling mechanism.

**Issue:**
The previous deserialization configuration was using `TypeNameHandling.Auto` in Newtonsoft.Json.  `TypeNameHandling.Auto` allows for automatic deserialization of types based on `$type` metadata embedded in the JSON.  If an attacker can control the JSON input, they can potentially inject malicious `$type` properties to instantiate arbitrary types, leading to Remote Code Execution (RCE) vulnerabilities. This is related to our test infrastructure, so the potential security impact does not include production code running on customers' devices

**Fix Implemented:**

To mitigate this risk, the following changes have been made:

1. **Disabled Automatic Type Name Handling (`TypeNameHandling.None`):**
    - The `TypeNameHandling` setting in `JsonSerializerSettings` has been explicitly set to `TypeNameHandling.None`.
    - This is because the serialized JSON in our use case does not include `$type` metadata.  Setting `TypeNameHandling.None` ensures that automatic `$type` processing is completely disabled, further enhancing security.
   
2.  **Implemented Secure Deserialization with KnownTypes Whitelist:**
    - Updated TypeNameSerializationBinder binder to utilize a `KnownTypes` whitelist, explicitly defining the set of allowed types that can be deserialized.
    - The deserializer is now configured to use this `SerializationBinder`, ensuring that only types present in the `KnownTypes` whitelist are permitted for deserialization. This significantly restricts the attack surface and prevents the instantiation of unauthorized or potentially malicious types.
    - This approach aligns with secure deserialization best practices and follows the guidance outlined in: [https://liquid.microsoft.com/Web/Object/Read/MS.Security/Requirements/Microsoft.Security.SystemsADM.10010#Zguide](https://liquid.microsoft.com/Web/Object/Read/MS.Security/Requirements/Microsoft.Security.SystemsADM.10010#Zguide)
    and recommendation: Solution using custom ISerializationBinder: [https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM02211#Zguide](https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM02211#Zguide)

**Tested the changes in the local:**

![image](https://github.com/user-attachments/assets/884e1f4b-aedd-42ba-9727-9d1f4089c4d2)

**References:**

https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM02211#Zguide
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2326
https://liquid.microsoft.com/Web/Object/Read/MS.Security/Requirements/Microsoft.Security.SystemsADM.10010#Zguide

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
