### PR TITLE
Upgrade 20.04 agents

### DIFF
--- a/builds/checkin/api-proxy.yaml
+++ b/builds/checkin/api-proxy.yaml
@@ -14,7 +14,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     steps:
       - bash: |
           git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(rust-toolchain\.toml|builds|edge-modules/api-proxy-module|mqtt/edgelet-client)'
@@ -34,7 +34,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     steps:
       - script: echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
         displayName: Set env variables

--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -13,7 +13,7 @@ jobs:
   pool:
     name: $(pool.linux.name)
     demands:
-    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+    - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
   steps:
   - bash: |
       git log -m -1 --name-only --first-parent --pretty="" | egrep -i -v '^(edgelet|doc|mqtt)'
@@ -33,7 +33,7 @@ jobs:
   pool:
     name: $(pool.linux.name)
     demands:
-    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+    - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
   steps:
   - script: scripts/linux/installPrereqs.sh
     displayName: Install Prerequisites
@@ -61,7 +61,7 @@ jobs:
   pool:
     name: $(pool.linux.name)
     demands:
-    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+    - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
   steps:
   - script: scripts/linux/installPrereqs.sh
     displayName: Install Prerequisites

--- a/builds/checkin/e2e-checkin.yaml
+++ b/builds/checkin/e2e-checkin.yaml
@@ -38,7 +38,7 @@ stages:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     dependsOn:
       - CheckBuildImages
       - CheckBuildPackages

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -13,7 +13,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     steps:
       - bash: |
           git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(rust-toolchain\.toml|builds|edgelet)'
@@ -33,7 +33,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     steps:
       - script: echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
         displayName: Set env variables
@@ -61,7 +61,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     variables:
       IOTEDGE_HOMEDIR: /tmp
     steps:
@@ -92,7 +92,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     variables:
       IOTEDGE_HOMEDIR: /tmp
     steps:
@@ -123,7 +123,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     steps:
       - script: echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
         displayName: Set env variables
@@ -145,7 +145,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     steps:
       - script: |
           echo "##vso[task.setvariable variable=IOTEDGE_HOMEDIR;]/tmp"

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -17,7 +17,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     variables:
       testEnvironment: linux
     steps:

--- a/builds/misc/templates/build-images.yaml
+++ b/builds/misc/templates/build-images.yaml
@@ -49,7 +49,7 @@ stages:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     dependsOn: CheckBuildImages
     jobs:
     - job: BuildDotnetComponents

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -12,7 +12,7 @@ stages:
     pool:
         name: $(pool.linux.name)
         demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+          - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
     dependsOn: []
     jobs:
       - job: check_source_change_edgelet
@@ -46,7 +46,7 @@ stages:
         pool:
           name: $(pool.linux.name)
           demands:
-            - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+            - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
         strategy:
           matrix:
             RedHat8-amd64:
@@ -339,7 +339,7 @@ stages:
           matrix:
             2.0-amd64:
               agent-pool: $(pool.linux.name)
-              agent-image: agent-aziotedge-ubuntu-20.04-docker
+              agent-image: agent-aziotedge-ubuntu-22.04-msmoby
               arch: amd64
               os: mariner
               os_id: cm
@@ -349,7 +349,7 @@ stages:
               target.iotedged: builds/mariner2/out/RPMS/x86_64
             2.0-aarch64:
               agent-pool: $(pool.linux.arm.name)
-              agent-image: agent-aziotedge-ubuntu-20.04-arm64-docker
+              agent-image: agent-aziotedge-ubuntu-22.04-arm64-msmoby
               arch: aarch64
               os: mariner
               os_id: cm

--- a/builds/misc/templates/build-rocksdb.yaml
+++ b/builds/misc/templates/build-rocksdb.yaml
@@ -5,15 +5,15 @@ jobs:
     matrix:
       amd64:
         pool_name: $(pool.linux.name)
-        agent_image: agent-aziotedge-ubuntu-20.04-docker
+        agent_image: agent-aziotedge-ubuntu-24.04-msmoby
         arch: amd64
       arm32:
         pool_name: $(pool.linux.arm.name)
-        agent_image: agent-aziotedge-ubuntu-20.04-arm64-docker
+        agent_image: agent-aziotedge-ubuntu-24.04-arm64-msmoby
         arch: arm32v7
       arm64:
         pool_name: $(pool.linux.arm.name)
-        agent_image: agent-aziotedge-ubuntu-20.04-arm64-docker
+        agent_image: agent-aziotedge-ubuntu-24.04-arm64-msmoby
         arch: arm64v8
   pool:
       name: $(pool_name)

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -26,7 +26,7 @@ variables:
 pool:
   name: $(pool.linux.name)
   demands:
-  - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+  - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
 
 steps:
 - checkout: product

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -17,7 +17,7 @@ variables:
 pool:
   name: $(pool.linux.name)
   demands:
-  - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+  - ImageOverride -equals agent-aziotedge-ubuntu-24.04-msmoby
 
 steps:
 - checkout: self


### PR DESCRIPTION
Ubuntu 20.04 will be out of support soon (May 2025). This PR upgrades most of our build/test agents to 24.04 (22.04 in the case of building Mariner) to ensure the agents are supported and secure.

To test, I ran all the affected pipelines and ensured they behaved properly with the newer agents.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.