### PR TITLE
Fix iotedged checkin pipeline

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -147,19 +147,16 @@ jobs:
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
-      - script: |
-          echo "##vso[task.setvariable variable=IOTEDGE_HOMEDIR;]/tmp"
-          echo "##vso[task.setvariable variable=CARGO;]${CARGO_HOME:-"$HOME/.cargo"}/bin/cargo"
-        displayName: Set env variables
-        workingDirectory: edgelet
       - script: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
       - script: |
-          $CARGO install --locked --version 0.26.1 cargo-tarpaulin
+          . "$HOME/.cargo/env"
+          cargo install --locked --version 0.26.1 cargo-tarpaulin
         workingDirectory: edgelet
         displayName: Install Cargo Tarpaulin
       - script: |
-          $CARGO tarpaulin --out Xml --output-dir .
+          . "$HOME/.cargo/env"
+          cargo tarpaulin --out Xml --output-dir .
         displayName: Test
         workingDirectory: edgelet
       - task: PublishCodeCoverageResults@2


### PR DESCRIPTION
Within the last few days the itoedged checkin pipeline has started failing in the code coverage job. I'm not sure what changed with rust or cargo or the cargo-tarpaulin tool, but the tool is no longer happy with the environment. I was able to fix it by sourcing the cargo environment instead of manually setting `CARGO="${CARGO_HOME:-"$HOME/.cargo"}/bin/cargo"`.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.