### PR TITLE
Clean up images when nested pipelines complete

### DIFF
--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -253,6 +253,7 @@ stages:
           sudo docker container prune --force
           sudo docker container rm --force $(docker container ls --all --quiet)
           sudo docker image prune --all --force
+        displayName: Clean
 
   - job:  Unlock_agents
     displayName: Unlock agents

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -250,7 +250,7 @@ stages:
       - bash: |
           set -x
           sudo systemctl stop aziot-*
-          sudo apt -y purge aziot-*
+          sudo apt-get -y purge aziot-*
           sudo docker container kill $(sudo docker container ls --quiet)  # stop all running containers
           sudo docker container prune --force                             # remove all stopped containers
           sudo docker image prune --all --force                           # remove all images

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -218,7 +218,22 @@ stages:
           EventHubCompatibleEndpoint: '$(IotHub-EventHubConnStr)'
           IotHubConnectionString: '$(IotHub-ConnStr)'
           test_type: $(test_type)
-
+      - template: templates/nested-isa95-unlock.yaml
+        parameters:
+          agentName: $(deviceLvl5AgentName)
+          nsgName: $(isa95_lock_lvl5.nsgName)
+      - template: templates/nested-isa95-unlock.yaml
+        parameters:
+          agentName: $(deviceLvl4AgentName)
+          nsgName: $(isa95_lock_lvl4.nsgName)
+      - template: templates/nested-isa95-unlock.yaml
+        parameters:
+          agentName: $(otProxyName)
+          nsgName: $(isa95_lock_lvl35.nsgName)
+      - template: templates/nested-isa95-unlock.yaml
+        parameters:
+          agentName: $(deviceLvl3AgentName)
+          nsgName: $(isa95_lock_lvl3.nsgName)
 
 - stage: Cleanup
   condition: always()
@@ -277,10 +292,6 @@ stages:
       deviceLvl5AgentName: $[ stageDependencies.RunISA95Tests.SetupVM_level5.outputs['exportAgentName.agentName'] ]
       deviceLvl4AgentName: $[ stageDependencies.RunISA95Tests.SetupVM_level4.outputs['exportAgentName.agentName'] ]
       deviceLvl3AgentName: $[ stageDependencies.RunISA95Tests.SetupVM_level3.outputs['exportAgentName.agentName'] ]
-      deviceLvl5NSGName: $[ stageDependencies.RunISA95Tests.Run_ISA95_test.outputs['isa95_lock_lvl5.nsgName'] ]
-      deviceLvl4NSGName: $[ stageDependencies.RunISA95Tests.Run_ISA95_test.outputs['isa95_lock_lvl4.nsgName'] ]
-      deviceLvl35NSGName: $[ stageDependencies.RunISA95Tests.Run_ISA95_test.outputs['isa95_lock_lvl35.nsgName'] ]
-      deviceLvl3NSGName: $[ stageDependencies.RunISA95Tests.Run_ISA95_test.outputs['isa95_lock_lvl3.nsgName'] ]
     pool:
       name: $(pool.name)
       demands:
@@ -305,19 +316,3 @@ stages:
           iotHubName: $(deviceLvl3IoTHubName)
           deviceId: $(deviceLvl3DeviceId)
           lvl: 3
-      - template: templates/nested-isa95-unlock.yaml
-        parameters:
-          agentName: $(deviceLvl5AgentName)
-          nsgName: $(deviceLvl5NSGName)
-      - template: templates/nested-isa95-unlock.yaml
-        parameters:
-          agentName: $(deviceLvl4AgentName)
-          nsgName: $(deviceLvl4NSGName)
-      - template: templates/nested-isa95-unlock.yaml
-        parameters:
-          agentName: $(otProxyName)
-          nsgName: $(deviceLvl35NSGName)
-      - template: templates/nested-isa95-unlock.yaml
-        parameters:
-          agentName: $(deviceLvl3AgentName)
-          nsgName: $(deviceLvl3NSGName)

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -182,12 +182,12 @@ stages:
       test_type: nestededge_isa95
       verbose: false
     pool:
-     name: $(pool.name)
-     demands:
-       - agent-group -equals $(agent.group)
-       - Agent.OS -equals Linux
-       - Agent.OSArchitecture -equals X64
-       - level -equals jumpbox
+      name: $(pool.name)
+      demands:
+        - agent-group -equals $(agent.group)
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - level -equals jumpbox
     steps:
       - template: templates/nested-get-secrets.yaml
       - template: templates/e2e-clean-directory.yaml
@@ -226,8 +226,38 @@ stages:
     - LockAgents
     - RunISA95Tests
   jobs:
+  - job: Clean_images
+    displayName: Clean up Docker images
+    strategy:
+      matrix:
+        L3:
+          level: 3
+        L4:
+          level: 4
+        L5:
+          level: 5
+        jumpbox:
+          level: jumpbox
+    pool:
+      name: $(pool.name)
+      demands:
+        - agent-group -equals $(agent.group)
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - level -equals $(level)
+    steps:
+      - bash: |
+          set -x
+          sudo systemctl stop aziot-*
+          sudo apt -y purge aziot-*
+          sudo docker container prune --force
+          sudo docker container rm --force $(docker container ls --all --quiet)
+          sudo docker image prune --all --force
+
   - job:  Unlock_agents
     displayName: Unlock agents
+    dependsOn: Clean_images
+    condition: always()
     timeoutInMinutes: 10
     pool:
       name: $(pool.name)
@@ -241,6 +271,8 @@ stages:
 
   - job:  Clean_up_identities
     displayName: Clean up identities
+    dependsOn: Clean_images
+    condition: always()
     timeoutInMinutes: 10
     variables:
       deviceLvl5DeviceId: $[ stageDependencies.RunISA95Tests.SetupVM_level5.outputs['createIdentity.parentDeviceId'] ]

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -237,7 +237,7 @@ stages:
           level: 4
         L5:
           level: 5
-        jumpbox:
+        Jumpbox:
           level: jumpbox
     pool:
       name: $(pool.name)

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -52,6 +52,7 @@ stages:
 
 - stage: RunISA95Tests
   dependsOn: LockAgents
+  condition: false
   jobs:
   - job: SetupVM_level5
     displayName: SettingUp level 5

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -289,6 +289,7 @@ stages:
       deviceLvl3DeviceId: $[ stageDependencies.RunISA95Tests.SetupVM_level3.outputs['createIdentity.parentDeviceId'] ]
       deviceLvl5IoTHubName: $[ stageDependencies.RunISA95Tests.SetupVM_level5.outputs['createIdentity.iotHubName'] ]
       deviceLvl4IoTHubName: $[ stageDependencies.RunISA95Tests.SetupVM_level4.outputs['createIdentity.iotHubName'] ]
+      deviceLvl3IoTHubName: $[ stageDependencies.RunISA95Tests.SetupVM_level3.outputs['createIdentity.iotHubName'] ]
       deviceLvl5AgentName: $[ stageDependencies.RunISA95Tests.SetupVM_level5.outputs['exportAgentName.agentName'] ]
       deviceLvl4AgentName: $[ stageDependencies.RunISA95Tests.SetupVM_level4.outputs['exportAgentName.agentName'] ]
       deviceLvl3AgentName: $[ stageDependencies.RunISA95Tests.SetupVM_level3.outputs['exportAgentName.agentName'] ]

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -271,6 +271,7 @@ stages:
     variables:
       deviceLvl5DeviceId: $[ stageDependencies.RunISA95Tests.SetupVM_level5.outputs['createIdentity.parentDeviceId'] ]
       deviceLvl4DeviceId: $[ stageDependencies.RunISA95Tests.SetupVM_level4.outputs['createIdentity.parentDeviceId'] ]
+      deviceLvl3DeviceId: $[ stageDependencies.RunISA95Tests.SetupVM_level3.outputs['createIdentity.parentDeviceId'] ]
       deviceLvl5IoTHubName: $[ stageDependencies.RunISA95Tests.SetupVM_level5.outputs['createIdentity.iotHubName'] ]
       deviceLvl4IoTHubName: $[ stageDependencies.RunISA95Tests.SetupVM_level4.outputs['createIdentity.iotHubName'] ]
       deviceLvl5AgentName: $[ stageDependencies.RunISA95Tests.SetupVM_level5.outputs['exportAgentName.agentName'] ]

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -251,7 +251,7 @@ stages:
           sudo systemctl stop aziot-*
           sudo apt -y purge aziot-*
           sudo docker container prune --force
-          sudo docker container rm --force $(docker container ls --all --quiet)
+          sudo docker container rm --force $(sudo docker container ls --all --quiet)
           sudo docker image prune --all --force
         displayName: Clean
 

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -250,9 +250,9 @@ stages:
           set -x
           sudo systemctl stop aziot-*
           sudo apt -y purge aziot-*
-          sudo docker container prune --force
-          sudo docker container rm --force $(sudo docker container ls --all --quiet)
-          sudo docker image prune --all --force
+          sudo docker container kill $(sudo docker container ls --quiet)  # stop all running containers
+          sudo docker container prune --force                             # remove all stopped containers
+          sudo docker image prune --all --force                           # remove all images
         displayName: Clean
 
   - job:  Unlock_agents

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -52,7 +52,6 @@ stages:
 
 - stage: RunISA95Tests
   dependsOn: LockAgents
-  condition: false
   jobs:
   - job: SetupVM_level5
     displayName: SettingUp level 5

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -247,14 +247,7 @@ stages:
         - Agent.OSArchitecture -equals X64
         - level -equals $(level)
     steps:
-      - bash: |
-          set -x
-          sudo systemctl stop aziot-*
-          sudo apt-get -y purge aziot-*
-          sudo docker container kill $(sudo docker container ls --quiet)  # stop all running containers
-          sudo docker container prune --force                             # remove all stopped containers
-          sudo docker image prune --all --force                           # remove all images
-        displayName: Clean
+      - template: templates/e2e-clean-all-images.yaml
 
   - job:  Unlock_agents
     displayName: Unlock agents

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -145,6 +145,7 @@ stages:
           sudo docker container prune --force
           sudo docker container rm --force $(docker container ls --all --quiet)
           sudo docker image prune --all --force
+        displayName: Clean
 
   - job:  Unlock_agents
     displayName: Unlock agents

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -140,6 +140,8 @@ stages:
     steps:
       - bash: |
           set -x
+          sudo systemctl stop aziot-*
+          sudo apt -y purge aziot-*
           sudo docker container prune --force
           sudo docker container rm --force $(docker container ls --all --quiet)
           sudo docker image prune --all --force

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -125,11 +125,11 @@ stages:
     strategy:
       matrix:
         L3:
-          status: unlocked_$(Build.BuildId)_L3_mqtt
+          status: 'unlocked_$(Build.BuildId)_L3_mqtt'
         L4:
-          status: unlocked_$(Build.BuildId)_L4_mqtt
+          status: 'unlocked_$(Build.BuildId)_L4_mqtt'
         L5:
-          status: unlocked_$(Build.BuildId)_L5_mqtt
+          status: 'unlocked_$(Build.BuildId)_L5_mqtt'
     pool:
       name: $(pool.name)
       demands:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -46,7 +46,6 @@ stages:
 
 - stage: RunNestedTests
   dependsOn: LockAgents
-  condition: false
   jobs:
   - template: templates/get-storage-uri.yaml
     parameters:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -46,6 +46,7 @@ stages:
 
 - stage: RunNestedTests
   dependsOn: LockAgents
+  condition: false
   jobs:
   - template: templates/get-storage-uri.yaml
     parameters:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -125,18 +125,18 @@ stages:
     strategy:
       matrix:
         L3:
-          level: L3
+          level: 3
         L4:
-          level: L4
+          level: 4
         L5:
-          level: L5
+          level: 5
     pool:
       name: $(pool.name)
       demands:
         - agent-group -equals $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals X64
-        - status -equals unlocked_$(Build.BuildId)_$(level)_mqtt
+        - status -equals unlocked_$(Build.BuildId)_L$(level)_mqtt
     steps:
       - bash: |
           set -x

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -126,18 +126,18 @@ stages:
     strategy:
       matrix:
         L3:
-          status: 'unlocked_$(Build.BuildId)_L3_mqtt'
+          level: L3
         L4:
-          status: 'unlocked_$(Build.BuildId)_L4_mqtt'
+          level: L4
         L5:
-          status: 'unlocked_$(Build.BuildId)_L5_mqtt'
+          level: L5
     pool:
       name: $(pool.name)
       demands:
         - agent-group -equals $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals X64
-        - status -equals $(status)
+        - status -equals unlocked_$(Build.BuildId)_$(level)_mqtt
     steps:
       - bash: |
           set -x

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -143,7 +143,7 @@ stages:
           sudo systemctl stop aziot-*
           sudo apt -y purge aziot-*
           sudo docker container prune --force
-          sudo docker container rm --force $(docker container ls --all --quiet)
+          sudo docker container rm --force $(sudo docker container ls --all --quiet)
           sudo docker image prune --all --force
         displayName: Clean
 

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -139,14 +139,7 @@ stages:
         - Agent.OSArchitecture -equals X64
         - status -equals unlocked_$(Build.BuildId)_L$(level)_mqtt
     steps:
-      - bash: |
-          set -x
-          sudo systemctl stop aziot-*
-          sudo apt-get -y purge aziot-*
-          sudo docker container kill $(sudo docker container ls --quiet)  # stop all running containers
-          sudo docker container prune --force                             # remove all stopped containers
-          sudo docker image prune --all --force                           # remove all images
-        displayName: Clean
+      - template: templates/e2e-clean-all-images.yaml
 
   - job:  Unlock_agents
     displayName: Unlock agents

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -142,7 +142,7 @@ stages:
       - bash: |
           set -x
           sudo systemctl stop aziot-*
-          sudo apt -y purge aziot-*
+          sudo apt-get -y purge aziot-*
           sudo docker container kill $(sudo docker container ls --quiet)  # stop all running containers
           sudo docker container prune --force                             # remove all stopped containers
           sudo docker image prune --all --force                           # remove all images

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -142,9 +142,9 @@ stages:
           set -x
           sudo systemctl stop aziot-*
           sudo apt -y purge aziot-*
-          sudo docker container prune --force
-          sudo docker container rm --force $(sudo docker container ls --all --quiet)
-          sudo docker image prune --all --force
+          sudo docker container kill $(sudo docker container ls --quiet)  # stop all running containers
+          sudo docker container prune --force                             # remove all stopped containers
+          sudo docker image prune --all --force                           # remove all images
         displayName: Clean
 
   - job:  Unlock_agents

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -120,8 +120,34 @@ stages:
     - LockAgents
     - RunNestedTests
   jobs:
+  - job: Clean_images
+    displayName: Clean up Docker images
+    strategy:
+      matrix:
+        L3:
+          status: unlocked_$(Build.BuildId)_L3_mqtt
+        L4:
+          status: unlocked_$(Build.BuildId)_L4_mqtt
+        L5:
+          status: unlocked_$(Build.BuildId)_L5_mqtt
+    pool:
+      name: $(pool.name)
+      demands:
+        - agent-group -equals $(agent.group)
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - status -equals $(status)
+    steps:
+      - bash: |
+          set -x
+          sudo docker container prune --force
+          sudo docker container rm --force $(docker container ls --all --quiet)
+          sudo docker image prune --all --force
+
   - job:  Unlock_agents
     displayName: Unlock agents
+    dependsOn: Clean_images
+    condition: always()
     timeoutInMinutes: 2
     pool:
       name: $(pool.name)
@@ -135,7 +161,9 @@ stages:
 
   - job:  Clean_up_identities
     displayName: Clean up identities
-    timeoutInMinutes: 2    
+    dependsOn: Clean_images
+    condition: always()
+    timeoutInMinutes: 2
     variables:    
       deviceLvl5DeviceId: $[ stageDependencies.RunNestedTests.SetupVM_level5_mqtt.outputs['createIdentity.parentDeviceId'] ] 
       deviceLvl4DeviceId: $[ stageDependencies.RunNestedTests.SetupVM_level4_mqtt.outputs['createIdentity.parentDeviceId'] ] 

--- a/builds/e2e/templates/e2e-clean-all-images.yaml
+++ b/builds/e2e/templates/e2e-clean-all-images.yaml
@@ -3,7 +3,12 @@ steps:
     set -x
     sudo systemctl stop aziot-*
     sudo apt-get -y purge aziot-*
-    sudo docker container kill $(sudo docker container ls --quiet)  # stop all running containers
-    sudo docker container prune --force                             # remove all stopped containers
-    sudo docker image prune --all --force                           # remove all images
+
+    containers=( $(sudo docker container ls --quiet) )  # get all running containers
+    if [ ${#containers[@]} -gt 0 ]; then
+      sudo docker container kill $containers            # stop all running containers
+    fi
+
+    sudo docker container prune --force                 # remove all stopped containers
+    sudo docker image prune --all --force               # remove all images
   displayName: Clean images

--- a/builds/e2e/templates/e2e-clean-all-images.yaml
+++ b/builds/e2e/templates/e2e-clean-all-images.yaml
@@ -1,0 +1,9 @@
+steps:
+- bash: |
+    set -x
+    sudo systemctl stop aziot-*
+    sudo apt-get -y purge aziot-*
+    sudo docker container kill $(sudo docker container ls --quiet)  # stop all running containers
+    sudo docker container prune --force                             # remove all stopped containers
+    sudo docker image prune --all --force                           # remove all images
+  displayName: Clean images

--- a/builds/e2e/templates/nested-clean-identity.yaml
+++ b/builds/e2e/templates/nested-clean-identity.yaml
@@ -12,6 +12,8 @@ steps:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        set -xeuo pipefail
+
         deviceId="${{ parameters.deviceId }}"
 
         if [ -z $deviceId ]; then
@@ -19,5 +21,4 @@ steps:
         fi
 
         echo "Deleting ${{ parameters.deviceId }} iotedge in iothub: ${{ parameters.iotHubName }}, in subscription $(azure.subscription)"
-        az iot hub device-identity delete -n ${{ parameters.iotHubName }} -d ${{ parameters.deviceId }}    
-
+        az iot hub device-identity delete -n ${{ parameters.iotHubName }} -d ${{ parameters.deviceId }} || true

--- a/builds/e2e/templates/nested-clean-identity.yaml
+++ b/builds/e2e/templates/nested-clean-identity.yaml
@@ -12,13 +12,9 @@ steps:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        set -xeuo pipefail
-
-        deviceId="${{ parameters.deviceId }}"
-
-        if [ -z $deviceId ]; then
-          exit 0
+        if [[ -z "${{ parameters.deviceId }}" || -z "${{ parameters.iotHubName }}" ]]; then
+          exit 1
         fi
 
-        echo "Deleting ${{ parameters.deviceId }} iotedge in iothub: ${{ parameters.iotHubName }}, in subscription $(azure.subscription)"
-        az iot hub device-identity delete -n ${{ parameters.iotHubName }} -d ${{ parameters.deviceId }} || true
+        echo "Deleting device ${{ parameters.deviceId }} from hub ${{ parameters.iotHubName }} in subscription $(azure.subscription)"
+        az iot hub device-identity delete -n ${{ parameters.iotHubName }} -d ${{ parameters.deviceId }}


### PR DESCRIPTION
This change impacts the the Nested End-to-end Tests and ISA-95 Smoke Test pipelines. It deletes Docker containers and images when the pipelines complete so they don't hang around on the custom pipeline agent and potentially trigger warnings during vulnerability scans.

Note that, for the ISA-95 Smoke Test pipeline, I had to move the network unlock logic to a new location. The new logic to clean images needs to reacquire the custom L3/L4/L5 agents, however I found that the Azure Pipelines service lost it's connection to the agents so it couldn't assign them jobs unless I unlocked the network first. This actually makes more sense anyway; the Run_ISA95_test job starts by locking the network and ends by unlocking it. It's more symmetric now.

I also found that two expected variables in the Clean_up_identities job of the ISA-95 Smoke Test pipeline were never being set, so the level 3 identity was never cleaned up (the test IoT hub had a whole bunch of stale identities hanging around). I made updates to set the variables.

To test, I ran the Nested End-to-end Tests and ISA-95 Smoke Test pipelines and confirmed that (1) they passed, and (2) the images were removed from the agents.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.