### PR TITLE
Use 1ES-hosted agent for Ubuntu 24.04 arm64

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -231,8 +231,9 @@ jobs:
     condition: succeeded('Token')
 
     pool:
-      name: $(pool.custom.name)
-      demands: ubuntu2404-arm64-e2e-tests
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-24.04-arm64-msmoby
 
     variables:
       os: linux

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -231,7 +231,7 @@ jobs:
     condition: succeeded('Token')
 
     pool:
-      name: $(pool.linux.name)
+      name: $(pool.linux.arm.name)
       demands:
       - ImageOverride -equals agent-aziotedge-ubuntu-24.04-arm64-msmoby
 


### PR DESCRIPTION
This change updates the Ubuntu 24.04 arm64 job in the end-to-end tests to use a 1ES-hosted agent instead of a custom agent. We created the corresponding 1ES-hosted image a while back but it didn't work because 1ES-internal software didn't support Ubuntu 24.04 arm64 at the time. That problem has since been resolved, so we can switch over now and decommision the custom agent VM we've been maintaining.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.