### PR TITLE
Fix API Proxy module build to mark the entrypoint executable.

### DIFF
--- a/edge-modules/api-proxy-module/docker/linux/amd64/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/amd64/Dockerfile
@@ -29,6 +29,15 @@ RUN chown -R nginx:nginx /app && \
 RUN touch /var/run/nginx/nginx.pid && \
         chown -R nginx:nginx /var/run/nginx/nginx.pid
 
+# The api-proxy-release pipeline in ADO uses PublishPipelineArtifact and DownloadPipelineArtifact tasks
+# to shuttle the binary between jobs (one compiles the binary and the other uses it to build the Docker image).
+# These tasks round-trip the file through a .zip container so the binary loses its +x mode bits.
+# So we fix up the mode manually.
+#
+# The build-image.yaml pipeline doesn't have this problem because it uses PublishBuildArtifacts and DownloadBuildArtifacts
+# with `storeAsTar: true` and `extractTars: true`, so the round-tripping happens in a .tar that preserves the mode bits.
+RUN chmod 0755 /app/api-proxy-module
+
 
 USER nginx
 

--- a/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
@@ -23,6 +23,16 @@ RUN chown -R nginx:nginx /app && \
 RUN touch /var/run/nginx.pid && \
         chown -R nginx:nginx /var/run/nginx.pid
 
+# The api-proxy-release pipeline in ADO uses PublishPipelineArtifact and DownloadPipelineArtifact tasks
+# to shuttle the binary between jobs (one compiles the binary and the other uses it to build the Docker image).
+# These tasks round-trip the file through a .zip container so the binary loses its +x mode bits.
+# So we fix up the mode manually.
+#
+# The build-image.yaml pipeline doesn't have this problem because it uses PublishBuildArtifacts and DownloadBuildArtifacts
+# with `storeAsTar: true` and `extractTars: true`, so the round-tripping happens in a .tar that preserves the mode bits.
+RUN chmod 0755 /app/api-proxy-module
+
+
 USER nginx
 
 #expose ports

--- a/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
@@ -23,6 +23,15 @@ RUN chown -R nginx:nginx /app && \
 RUN touch /var/run/nginx.pid && \
         chown -R nginx:nginx /var/run/nginx.pid
 
+# The api-proxy-release pipeline in ADO uses PublishPipelineArtifact and DownloadPipelineArtifact tasks
+# to shuttle the binary between jobs (one compiles the binary and the other uses it to build the Docker image).
+# These tasks round-trip the file through a .zip container so the binary loses its +x mode bits.
+# So we fix up the mode manually.
+#
+# The build-image.yaml pipeline doesn't have this problem because it uses PublishBuildArtifacts and DownloadBuildArtifacts
+# with `storeAsTar: true` and `extractTars: true`, so the round-tripping happens in a .tar that preserves the mode bits.
+RUN chmod 0755 /app/api-proxy-module
+
 
 USER nginx
 


### PR DESCRIPTION
The ADO release pipeline for this image ends up losing the +x mode bits on the binary because it uses ADO tasks that round-trip the binary through a .zip.

This went unnoticed in CI like the ISA95 pipeline, because those rely on images built by the regular build-images pipeline that does not have this problem, because it uses tasks that round-trip through a .tar instead.