### PR TITLE
Rebuild API Proxy when any arch-specific base image is out of date

### DIFF
--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -36,8 +36,7 @@ steps:
     #!/bin/bash
     set -euo pipefail
 
-    #branch="${BUILD_SOURCEBRANCH#refs/heads/}"
-    branch=main
+    branch="${BUILD_SOURCEBRANCH#refs/heads/}"
     echo "Filtering product-versions.json for images on branch '$branch'"
 
     # transform product-versions.json into a list of images for each product in this branch

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -36,7 +36,8 @@ steps:
     #!/bin/bash
     set -euo pipefail
 
-    branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+    #branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+    branch=main
     echo "Filtering product-versions.json for images on branch '$branch'"
 
     # transform product-versions.json into a list of images for each product in this branch

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -105,6 +105,9 @@ steps:
       # $base_images contains entries in the form of:
       # mcr.microsoft.com/dotnet/runtime@6.0-alpine,sha256:b7a9b8fbdb096327a1e05cda40d40afbec54b96e1a6a1bb7577e67344f9d99e4
 
+      # rebuild the multi-platform image if *any* of its base images are out of date
+      remove_image=true
+
       for base_info in ${base_images[@]}; do
         IFS=',' read base_image current_digest <<< "$base_info"
         latest_digest="$(docker buildx imagetools inspect $base_image --format '{{json .Manifest}}' | jq -r '.digest')"
@@ -113,10 +116,14 @@ steps:
         if [ -n "$current_digest" ] && [ "$current_digest" != "$latest_digest" ]
         then
           echo "  ## NEEDS UPDATE ##"
-        else
-          remove+=( "$image" )
+          remove_image=false
         fi
       done
+
+      if [ "$remove_image" == 'true' ]
+      then
+        remove+=( "$image" )
+      fi
     done
 
     # filter up-to-date images out of the list


### PR DESCRIPTION
For a given multi-platform image (say, Edge Agent or API Proxy), we currently auto-refresh the image only when _all_ corresponding base images are out of date. The _all_ vs. _any_ distinction isn't important for our .NET based images because they only have one (multi-platform) base image anyway. But API Proxy consists of three platform-specific images built from different base images. We need to refresh API Proxy when _any_ base image is out of date, otherwise vulnerabilities in, say, the arm64 image will go unpatched until there are also security patches for vulnerabilities in the arm32 and amd64 images.

This change updates our detection pipeline logic to mark a multi-platform image for refresh if any of its constituent base images are out of date.

To test, I ran the detection pipeline and confirmed that the list of images to build includes API Proxy, even though the amd64 platform-specific image doesn't currently need to be patched.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.