### PR TITLE
Adapt image detection logic to metadata format

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -163,8 +163,8 @@ jobs:
         displayName: Publish code coverage results
         inputs:
           summaryFileLocation: "edgelet/cobertura.xml"
-      - task: BuildQualityChecks@9
-        displayName: "Check build quality"
+      - task: BuildQualityChecks@10
+        displayName: Check build quality
         inputs:
           checkCoverage: true
           coverageFailOption: fixed

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -94,7 +94,9 @@ steps:
         docker buildx imagetools inspect --format "{{json .Provenance}}" $image | jq -r '
           . as $doc | [
             keys[] | $doc[.] | [
-              .SLSA // halt | .materials[] | select(.uri | startswith("pkg:docker/docker/dockerfile") | not)
+              .SLSA // halt | .buildDefinition.resolvedDependencies[] | select(
+                .uri | startswith("pkg:docker/docker/dockerfile") | not
+              ) 
             ] | if length == 1 then first else (
               "Error: inspect command found more than one base image in provenance materials\n\(.)" | halt_error
             ) end | "\(.uri | sub("pkg:docker/(?<i>.+)@(?<t>.+)\\?.+"; "\(.i):\(.t)")),sha256:\(.digest.sha256)"

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -36,7 +36,8 @@ steps:
     #!/bin/bash
     set -euo pipefail
 
-    branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+    #branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+    branch='main' # TODO: REVERT
     echo "Filtering product-versions.json for images on branch '$branch'"
 
     # transform product-versions.json into a list of images for each product in this branch

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -36,8 +36,7 @@ steps:
     #!/bin/bash
     set -euo pipefail
 
-    #branch="${BUILD_SOURCEBRANCH#refs/heads/}"
-    branch='main' # TODO: REVERT
+    branch="${BUILD_SOURCEBRANCH#refs/heads/}"
     echo "Filtering product-versions.json for images on branch '$branch'"
 
     # transform product-versions.json into a list of images for each product in this branch


### PR DESCRIPTION
We have a pipeline that runs daily to detect when the base images that underpin our product images (agent, hub, tempSensor, diagnostics, metrics collector, api proxy) have been updated. That pipeline has been failing the past few days due to a change in the format of the metadata we're reading off our images. I'm not sure whether the format actually changed, or if recent updates to our release pipelines changed the type of metadata that is being saved to the images. Either way, we needed to adapt our detection pipeline so it can read the image metadata.

To test, I ran the detection pipeline against this PR and confirmed it succeeds.

Note: I also updated the version of the BuildQualityChecks task in the iotedged checkin pipeline, since code coverage was failing. It passes now, but I'm guessing the problem is intermittent and might have been fixed simply by queuing another run (no version upgrade). But the updated task version doesn't hurt either.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.