### PR TITLE
Extend Azure CLI timeout for tests on arm32v7

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/packages.lock.json
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/packages.lock.json
@@ -34,6 +34,23 @@
           "System.Diagnostics.TraceSource": "4.3.0"
         }
       },
+      "Microsoft.Azure.Devices.Client": {
+        "type": "Direct",
+        "requested": "[1.42.3, )",
+        "resolved": "1.42.3",
+        "contentHash": "U0u26o1Bc/h+Qq3AHek82BfUabkPie3eWtCqHFxDT9y0TIm/ZkdX2nNRYqkdfjexQEewUJXetfDRXKxR9gXY4g==",
+        "dependencies": {
+          "Azure.Storage.Blobs": "12.19.1",
+          "DotNetty.Codecs.Mqtt": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Handlers": "0.7.6",
+          "Microsoft.Azure.Amqp": "2.5.12",
+          "Microsoft.Azure.Devices.Shared": "1.30.4",
+          "Microsoft.Win32.Registry": "4.5.0",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Configuration.ConfigurationManager": "4.4.1"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.3.1, )",
@@ -260,21 +277,6 @@
         "type": "Transitive",
         "resolved": "2.6.9",
         "contentHash": "5i9XzfqxK1H5IBl+OuOV1jwJdrOvi5RUwsZgVOryZm0GCzcM9NWPNRxzPAbsSeaR2T6+1gGvdT3vR+Vbha6KFQ=="
-      },
-      "Microsoft.Azure.Devices.Client": {
-        "type": "Transitive",
-        "resolved": "1.36.10",
-        "contentHash": "jzvpHqH/FgyAPvDgQVrpgFhqzbo9FA5k5nqfRRZ6ghTGUsEmtjUGCbzvq9m2tm970G8HBOv7vwqgC7X678JXiw==",
-        "dependencies": {
-          "Azure.Storage.Blobs": "12.19.1",
-          "DotNetty.Codecs.Mqtt": "0.7.6",
-          "DotNetty.Handlers": "0.7.6",
-          "Microsoft.Azure.Amqp": "2.5.12",
-          "Microsoft.Azure.Devices.Shared": "1.27.2",
-          "Microsoft.Win32.Registry": "4.5.0",
-          "Newtonsoft.Json": "12.0.3",
-          "System.Configuration.ConfigurationManager": "4.4.1"
-        }
       },
       "Microsoft.Azure.Devices.Shared": {
         "type": "Transitive",

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
+    using global::Azure.Identity;
     using global::Azure.Messaging.EventHubs;
     using global::Azure.Messaging.EventHubs.Consumer;
     using global::Azure.Messaging.EventHubs.Primitives;
@@ -18,7 +19,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
     public class IotHub
     {
-        readonly global::Azure.Identity.AzureCliCredential credential;
+        readonly AzureCliCredential credential;
         readonly string eventHubName;
         readonly string eventHubNamespace;
         readonly Lazy<Task<int>> eventHubPartitionCount;

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using global::Azure.Identity;
     using global::Azure.Messaging.EventHubs;
     using global::Azure.Messaging.EventHubs.Consumer;
     using global::Azure.Messaging.EventHubs.Primitives;
@@ -41,7 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                     proxy.ForEach(p => settings.Proxy = p);
                     return RegistryManager.Create(
                         this.iotHubHostname,
-                        new AzureCliCredential(),
+                        OsPlatform.CreateAzureCliCredential(),
                         settings);
                 });
 
@@ -52,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                     proxy.ForEach(p => settings.HttpProxy = p);
                     return ServiceClient.Create(
                         this.iotHubHostname,
-                        new AzureCliCredential(),
+                        OsPlatform.CreateAzureCliCredential(),
                         DeviceTransportType.Amqp_WebSocket_Only,
                         settings);
                 });
@@ -71,7 +70,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                         EventHubConsumerClient.DefaultConsumerGroupName,
                         this.eventHubNamespace,
                         this.eventHubName,
-                        new AzureCliCredential(),
+                        OsPlatform.CreateAzureCliCredential(),
                         consumerOptions);
 
                     return consumer.GetPartitionIdsAsync()
@@ -228,7 +227,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 EventPosition.FromEnqueuedTime(seekTime),
                 this.eventHubNamespace,
                 this.eventHubName,
-                new AzureCliCredential());
+                OsPlatform.CreateAzureCliCredential());
 
             var result = new TaskCompletionSource<bool>();
             using (token.Register(() => result.TrySetCanceled()))

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -28,9 +28,22 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         readonly Lazy<ServiceClient> serviceClient;
         static readonly TimeSpan eventHubRequestDuration = TimeSpan.FromSeconds(20);
 
+        static AzureCliCredential CreateAzureCliCredential()
+        {
+            if (OsPlatform.IsArm() && OsPlatform.Is32Bit())
+            {
+                return new AzureCliCredential(new AzureCliCredentialOptions
+                {
+                    ProcessTimeout = TimeSpan.FromSeconds(60)
+                });
+            }
+
+            return new AzureCliCredential();
+        }
+
         public IotHub(string iotHubHostname, string eventHubName, string eventHubNamespace, Option<Uri> proxyUri)
         {
-            this.credential = OsPlatform.CreateAzureCliCredential();
+            this.credential = IotHub.CreateAzureCliCredential();
             this.eventHubName = eventHubName;
             this.eventHubNamespace = eventHubNamespace;
             this.iotHubHostname = iotHubHostname;

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
     public class IotHub
     {
+        readonly global::Azure.Identity.AzureCliCredential credential;
         readonly string eventHubName;
         readonly string eventHubNamespace;
         readonly Lazy<Task<int>> eventHubPartitionCount;
@@ -28,6 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
         public IotHub(string iotHubHostname, string eventHubName, string eventHubNamespace, Option<Uri> proxyUri)
         {
+            this.credential = OsPlatform.CreateAzureCliCredential();
             this.eventHubName = eventHubName;
             this.eventHubNamespace = eventHubNamespace;
             this.iotHubHostname = iotHubHostname;
@@ -40,7 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                     proxy.ForEach(p => settings.Proxy = p);
                     return RegistryManager.Create(
                         this.iotHubHostname,
-                        OsPlatform.CreateAzureCliCredential(),
+                        this.credential,
                         settings);
                 });
 
@@ -51,7 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                     proxy.ForEach(p => settings.HttpProxy = p);
                     return ServiceClient.Create(
                         this.iotHubHostname,
-                        OsPlatform.CreateAzureCliCredential(),
+                        this.credential,
                         DeviceTransportType.Amqp_WebSocket_Only,
                         settings);
                 });
@@ -70,7 +72,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                         EventHubConsumerClient.DefaultConsumerGroupName,
                         this.eventHubNamespace,
                         this.eventHubName,
-                        OsPlatform.CreateAzureCliCredential(),
+                        this.credential,
                         consumerOptions);
 
                     return consumer.GetPartitionIdsAsync()
@@ -227,7 +229,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 EventPosition.FromEnqueuedTime(seekTime),
                 this.eventHubNamespace,
                 this.eventHubName,
-                OsPlatform.CreateAzureCliCredential());
+                this.credential);
 
             var result = new TaskCompletionSource<bool>();
             using (token.Register(() => result.TrySetCanceled()))

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/OsPlatform.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
-    using global::Azure.Identity;
     using Microsoft.Azure.Devices.Edge.Test.Common.Certs;
     using Microsoft.Azure.Devices.Edge.Util;
     using Serilog;
@@ -18,22 +17,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     {
         public static readonly IOsPlatform Current = new Linux.OsPlatform();
 
+        public static bool Is32Bit() => RuntimeInformation.OSArchitecture == Architecture.X86 || RuntimeInformation.OSArchitecture == Architecture.Arm;
+
         public static bool Is64Bit() => RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.Arm64;
 
         public static bool IsArm() => RuntimeInformation.OSArchitecture == Architecture.Arm || RuntimeInformation.OSArchitecture == Architecture.Arm64;
-
-        public static AzureCliCredential CreateAzureCliCredential()
-        {
-            if (RuntimeInformation.OSArchitecture == Architecture.Arm)
-            {
-                return new AzureCliCredential(new AzureCliCredentialOptions
-                {
-                    ProcessTimeout = TimeSpan.FromSeconds(60)
-                });
-            }
-
-            return new AzureCliCredential();
-        }
 
         protected async Task InstallRootCertificateAsync(
             string basePath,

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/OsPlatform.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
+    using global::Azure.Identity;
     using Microsoft.Azure.Devices.Edge.Test.Common.Certs;
     using Microsoft.Azure.Devices.Edge.Util;
     using Serilog;
@@ -20,6 +21,19 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         public static bool Is64Bit() => RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.Arm64;
 
         public static bool IsArm() => RuntimeInformation.OSArchitecture == Architecture.Arm || RuntimeInformation.OSArchitecture == Architecture.Arm64;
+
+        public static AzureCliCredential CreateAzureCliCredential()
+        {
+            if (RuntimeInformation.OSArchitecture == Architecture.Arm)
+            {
+                return new AzureCliCredential(new AzureCliCredentialOptions
+                {
+                    ProcessTimeout = TimeSpan.FromSeconds(60)
+                });
+            }
+
+            return new AzureCliCredential();
+        }
 
         protected async Task InstallRootCertificateAsync(
             string basePath,


### PR DESCRIPTION
The end-to-end tests were intermittently (but frequently) failing on Debian 11 arm32v7, which is running on an old Raspberry Pi 3B agent (i.e., slow). We're only running the end-to-end tests on this platform in "minimal" mode, meaning we're just running one basic test--TempSensor--but it was still failing. The problem seems to be that getting a token from the Azure CLI (as with `az account get-access-token`) can be pretty slow on the old Pi, and can timeout.

I did two things to reduce the chances of failure:
1. In the Microsoft.Azure.Devices.Edge.Test.Common.IotHub class, where the Azure CLI credential is required in four different places (three in the constructor alone), cache and use a single instance of the credential rather than doing `new AzureCliCredential()` each time. This translates to just a single `az account get-access-token` call.
2. If we're requesting a new AzureCliCredential on an arm32v7 platform, then increase the timeout for the `az account get-access-token` call from the default 13 seconds to 60 seconds.

I ran the end-to-end tests a couple times against the change and they pass on all platforms.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.