### PR TITLE
Fix docker host mismatch

### DIFF
--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -46,10 +46,10 @@ function setup_iotedge() {
         echo "image = \"\$upstream:443/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label\"" | sudo tee -a /etc/aziot/config.toml
     else
         echo "image = \"${CONTAINER_REGISTRY}/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label\"" | sudo tee -a /etc/aziot/config.toml
-    fi    
+    fi
     echo "createOptions = { }" | sudo tee -a /etc/aziot/config.toml
     echo "" | sudo tee -a  /etc/aziot/config.toml
-    
+
     if [ -z $PARENT_NAME ]; then
         echo "[agent.config.auth]" | sudo tee -a /etc/aziot/config.toml
         echo "serveraddress = \"${CONTAINER_REGISTRY}\"" | sudo tee -a /etc/aziot/config.toml
@@ -61,7 +61,7 @@ function setup_iotedge() {
     if [ ! -z $PROXY_ADDRESS ]; then
         echo "Configuring the bootstrapping edgeAgent to use http proxy"
         echo "[agent.env]" | sudo tee -a /etc/aziot/config.toml
-        echo "https_proxy = \"${PROXY_ADDRESS}\"" | sudo tee -a /etc/aziot/config.toml        
+        echo "https_proxy = \"${PROXY_ADDRESS}\"" | sudo tee -a /etc/aziot/config.toml
         echo "" | sudo tee -a /etc/aziot/config.toml
 
         echo "Adding proxy configuration to docker"
@@ -77,7 +77,7 @@ function setup_iotedge() {
         { echo "[Service]";
         echo "Environment=HTTPS_PROXY=${PROXY_ADDRESS}";
         } | sudo tee /etc/systemd/system/aziot-identityd.service.d/proxy.conf
-        sudo systemctl daemon-reload           
+        sudo systemctl daemon-reload
 
         echo "Adding proxy configuration to IoT Edge daemon"
         sudo mkdir -p /etc/systemd/system/aziot-edged.service.d/
@@ -173,7 +173,7 @@ function process_args() {
         elif [ $saveNextArg -eq 16 ]; then
             CONNECTION_STRING="$arg"
             saveNextArg=0
-        # 5/22/2024 - Temporary work around the issue where the az cli command cannot authorize itself within *.sh script using the service principal's service connection                
+        # 5/22/2024 - Temporary work around the issue where the az cli command cannot authorize itself within *.sh script using the service principal's service connection
         # elif [ $saveNextArg -eq 17 ]; then
         #     DEVICE_ID="$arg"
         #     saveNextArg=0

--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -52,7 +52,7 @@ function setup_iotedge() {
     
     if [ -z $PARENT_NAME ]; then
         echo "[agent.config.auth]" | sudo tee -a /etc/aziot/config.toml
-        echo "serveraddress = \"${CONTAINER_REGISTRY}\"" | sudo tee -a /etc/aziot/config.toml
+        echo "serveraddress = \"${CONTAINER_REGISTRY}:443\"" | sudo tee -a /etc/aziot/config.toml
         echo "username = \"${CONTAINER_REGISTRY_USERNAME}\"" | sudo tee -a /etc/aziot/config.toml
         echo "password = \"${CONTAINER_REGISTRY_PASSWORD}\"" | sudo tee -a /etc/aziot/config.toml
         echo "" | sudo tee -a  /etc/aziot/config.toml

--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -45,14 +45,14 @@ function setup_iotedge() {
     if [ ! -z $PARENT_NAME ]; then
         echo "image = \"\$upstream:443/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label\"" | sudo tee -a /etc/aziot/config.toml
     else
-        echo "image = \"${CONTAINER_REGISTRY}:443/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label\"" | sudo tee -a /etc/aziot/config.toml
+        echo "image = \"${CONTAINER_REGISTRY}/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label\"" | sudo tee -a /etc/aziot/config.toml
     fi    
     echo "createOptions = { }" | sudo tee -a /etc/aziot/config.toml
     echo "" | sudo tee -a  /etc/aziot/config.toml
     
     if [ -z $PARENT_NAME ]; then
         echo "[agent.config.auth]" | sudo tee -a /etc/aziot/config.toml
-        echo "serveraddress = \"${CONTAINER_REGISTRY}:443\"" | sudo tee -a /etc/aziot/config.toml
+        echo "serveraddress = \"${CONTAINER_REGISTRY}\"" | sudo tee -a /etc/aziot/config.toml
         echo "username = \"${CONTAINER_REGISTRY_USERNAME}\"" | sudo tee -a /etc/aziot/config.toml
         echo "password = \"${CONTAINER_REGISTRY_PASSWORD}\"" | sudo tee -a /etc/aziot/config.toml
         echo "" | sudo tee -a  /etc/aziot/config.toml


### PR DESCRIPTION
When the ISA95 smoke test pipeline generates the config file for aziot-edged, it generates slightly different values for `agent.config.auth.serveraddress` and `agent.config.image`. In the latter, it appends `:443` to the container registry's address. It seems that some recent change to the test environment has caused Docker to complain that serveraddress and image are different and then fail the pull operation. This leaves IoT Edge in an inconsistent state and the tests fail.

This change removes the logic that appends the port in the image. It also removes trailing whitespace in the script.

I confirmed that the ISA95 smoke tests pass with this change.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.