### PR TITLE
Remove support for Debian 11

### DIFF
--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -35,11 +35,6 @@ jobs:
     demands:
     - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
   steps:
-  - task: UseDotNet@2
-    displayName: Install .NET 10 SDK
-    inputs:
-      packageType: sdk
-      version: 10.0.x
   - script: scripts/linux/installPrereqs.sh
     displayName: Install Prerequisites
   - script: |
@@ -68,11 +63,6 @@ jobs:
     demands:
     - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
   steps:
-  - task: UseDotNet@2
-    displayName: Install .NET 10 SDK
-    inputs:
-      packageType: sdk
-      version: 10.0.x
   - script: scripts/linux/installPrereqs.sh
     displayName: Install Prerequisites
   - script: |

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -31,11 +31,6 @@ jobs:
             IotDevice2ConnStr2,
             IotDevice3ConnStr2,
             IotHubMqttHeadCert
-      - task: UseDotNet@2
-        displayName: Install .NET 10 SDK
-        inputs:
-          packageType: sdk
-          version: 10.0.x
       - task: Bash@3
         displayName: Install Prerequisites
         inputs:

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -306,8 +306,8 @@ jobs:
         - agent-osbits -equals 32
         - run-connectivity -equals true
     variables:
-      identity.artifact.name: 'aziot-identity-debian11-arm32v7'
-      edgelet.artifact.name: 'iotedged-debian11-arm32v7'
+      identity.artifact.name: 'aziot-identity-debian12-arm32v7'
+      edgelet.artifact.name: 'iotedged-debian12-arm32v7'
       sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
       cr.server: $[ dependencies.ContainerRegistryCredentials.outputs['acrgen.acrServer'] ]
       cr.username: $[ dependencies.ContainerRegistryCredentials.outputs['acrgen.acrUsername'] ]

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -45,56 +45,6 @@ jobs:
           serviceConnection: '$(az.subscription)'
 
 ################################################################################
-  - job: debian_11_arm32v7
-################################################################################
-    displayName: Debian 11 arm32v7 (minimal)
-    dependsOn:
-    - Token
-    - ContainerRegistryCredentials
-    condition: succeeded('Token')
-
-    pool:
-      name: $(pool.custom.name)
-      demands: deb11-e2e-tests
-
-    variables:
-      os: linux
-      arch: arm32v7
-      identityArtifactName: aziot-identity-debian11-arm32v7
-      artifactName: iotedged-debian11-arm32v7
-      dpsGroupKeySymmetric: $[ dependencies.Token.outputs['secrets.dpsGroupKeySymmetric'] ]
-      rootCaCertificate: $[ dependencies.Token.outputs['secrets.rootCaCertificate'] ]
-      rootCaKey: $[ dependencies.Token.outputs['secrets.rootCaKey'] ]
-      rootCaPassword: $[ dependencies.Token.outputs['secrets.rootCaPassword'] ]
-      sas_uri: $[ dependencies.Token.outputs['generate.sas_uri'] ]
-      containerRegistryServer: $[ dependencies.ContainerRegistryCredentials.outputs['acrgen.acrServer'] ]
-      containerRegistryUsername: $[ dependencies.ContainerRegistryCredentials.outputs['acrgen.acrUsername'] ]
-      containerRegistryPassword: $[ dependencies.ContainerRegistryCredentials.outputs['acrgen.acrPassword'] ]
-      minimal: true
-
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-      parameters:
-        containerRegistryServer: '$(containerRegistryServer)'
-        containerRegistryUsername: '$(containerRegistryUsername)'
-        dpsIdScope: '$(dps.idScope)'
-        eventHubName: '$(eventhub.name)'
-        eventHubFullyQualitifiedNamespace: '$(eventhub.namespace.fqdn)'
-        iotHubHostName: '$(iothub.hostname)'
-        iotHubResourceId: '$(iothub.resourceid)'
-        rootCaCertificate: '$(rootCaCertificate)'
-        rootCaKey: '$(rootCaKey)'
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
-      parameters:
-        azureSubscription: '$(az.subscription)'
-        containerRegistryPassword: '$(containerRegistryPassword)'
-        dpsGroupKeySymmetric: '$(dpsGroupKeySymmetric)'
-        rootCaPassword: '$(rootCaPassword)'
-        sas_uri: '$(sas_uri)'
-
-################################################################################
   - job: debian_12_amd64
 ################################################################################
     displayName: Debian 12 amd64

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -112,11 +112,6 @@ steps:
       ROOT_CERT: ${{ parameters.rootCaCertificate }}
       ROOT_KEY: ${{ parameters.rootCaKey }}
 
-  - task: UseDotNet@2
-    displayName: Install .NET 10 SDK
-    inputs:
-      packageType: sdk
-      version: 10.0.x
   - pwsh: |
       $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
       dotnet build $testDir

--- a/builds/misc/templates/build-images.yaml
+++ b/builds/misc/templates/build-images.yaml
@@ -67,11 +67,6 @@ stages:
       variables:
         Codeql.Enabled: true
       steps:
-      - task: UseDotNet@2
-        displayName: Install .NET 10 SDK
-        inputs:
-          packageType: sdk
-          version: 10.0.x
       - script: scripts/linux/buildBranch.sh -c $(Build.Configuration) --no-rocksdb-bin ${{ iif(parameters.build_single, '--skip-quickstart', '') }}
         name: build
         displayName: Build ($(Build.Configuration)) dotnet artifacts

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -22,20 +22,6 @@ parameters:
             identity: iot-identity-service/packages/el9/amd64
             iotedged: edgelet/target/rpmbuild/RPMS/x86_64
       - os:
-          container: mcr.microsoft.com/mirror/docker/library/debian:bullseye
-          identity: debian:11
-          iotedge: debian11
-        targets:
-          - arch: amd64
-            identity: iot-identity-service/packages/debian11/amd64
-            iotedged: edgelet/target/release
-          - arch: arm32v7
-            identity: iot-identity-service/packages/debian11/arm32v7
-            iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
-          - arch: aarch64
-            identity: iot-identity-service/packages/debian11/aarch64
-            iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
-      - os:
           container: mcr.microsoft.com/mirror/docker/library/debian:bookworm
           identity: debian:12
           iotedge: debian12

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -44,12 +44,6 @@ steps:
     ROOT_CERT: $(TestRootCaCertificate)
     ROOT_KEY: $(TestRootCaKey)
 
-- task: UseDotNet@2
-  displayName: Install .NET 10 SDK
-  inputs:
-    packageType: sdk
-    version: 10.0.x
-
 - pwsh: |
     $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
     dotnet build $testDir

--- a/edgelet/build/linux/package.sh
+++ b/edgelet/build/linux/package.sh
@@ -51,10 +51,6 @@ case "$PACKAGE_OS" in
         esac
         ;;
 
-    'debian11')
-        DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/debian:bullseye-slim'
-        ;;
-
     'debian12')
         DOCKER_IMAGE='mcr.microsoft.com/mirror/docker/library/debian:bookworm-slim'
         ;;

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -13,7 +13,7 @@ There are two options for building the IoT Edge Security Daemon.
 
 Linux packages are built using the `edgelet/build/linux/package.sh` script. Set the following environment variables, then invoke the script:
 
-1. `PACKAGE_OS`: This is the OS on which the resulting packages will be installed. It should be one of `redhat8`, `redhat9`, `debian11`, `debian12`, `ubuntu22.04`, or `ubuntu24.04`.
+1. `PACKAGE_OS`: This is the OS on which the resulting packages will be installed. It should be one of `redhat8`, `redhat9`, `debian12`, `ubuntu22.04`, or `ubuntu24.04`.
 
 1. `PACKAGE_ARCH`: This is the architecture of the OS on which the resulting packages will be installed. It should be one of `amd64`, `arm32v7` or `aarch64`.
 
@@ -67,7 +67,7 @@ dnf install -y \
     libcurl-devel libuuid-devel openssl-devel &&
 ```
 
-#### Debian 11-12
+#### Debian 12
 
 ```sh
 apt-get update

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                         : SupportedPackageExtension.Deb;
                     break;
                 case "debian":
-                    if (version != "11" && version != "12")
+                    if (version != "12")
                     {
                         ThrowUnsupportedOs();
                     }


### PR DESCRIPTION
Debian 11 LTS will not be supported in the upcoming IoT Edge 1.6 release because it will reach end of life so soon after the IoT Edge release (Debian 11 LTS end of life is Aug 31, 2026). It will, however, continue to be supported in IoT Edge 1.5.

This change updates the main branch to remove support for Debian 11.

It also removes the UseDotNet@2 task from several pipelines. They were added to our pipelines temporarily, before our 1ES-hosted images were updated with .NET 10. Now that the images have been updated, the tasks are no longer needed. Also, the tasks cause problems on our Debian 12 arm32v7 agent (possibly the UseDotNet task doesn't support installing on arm32v7?).

I ran all the pipelines, confirmed they pass, and confirmed that Debian 11 host packages are not produced.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.