### PR TITLE
Delete leaf device identities in one-time test teardown

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Context.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Configuration;
@@ -137,6 +139,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         public Option<string> ParentDeviceId { get; }
 
         public Dictionary<string, EdgeDevice> DeleteList { get; } = new Dictionary<string, EdgeDevice>();
+
+        public Dictionary<string, LeafDevice> LeafDeleteList { get; } = new Dictionary<string, LeafDevice>();
 
         public Option<string> DpsIdScope { get; }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
@@ -39,18 +39,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.None<string>(),
                 this.device.NestedEdge.IsNestedEdge);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    DateTime seekTime = DateTime.Now;
-                    await leaf.SendEventAsync(token);
-                    await leaf.WaitForEventsReceivedAsync(seekTime, token);
-                    await leaf.InvokeDirectMethodAsync(token);
-                },
-                async () =>
-                {
-                    await leaf.DeleteIdentityAsync(token);
-                });
+            Context.Current.LeafDeleteList.TryAdd(leafDeviceId, leaf);
+
+            DateTime seekTime = DateTime.Now;
+            await leaf.SendEventAsync(token);
+            await leaf.WaitForEventsReceivedAsync(seekTime, token);
+            await leaf.InvokeDirectMethodAsync(token);
         }
 
         [Test]
@@ -79,19 +73,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.None<string>(),
                 this.device.NestedEdge.IsNestedEdge);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    DateTime seekTime = DateTime.Now;
-                    await leaf.SendEventAsync(token);
-                    await leaf.WaitForEventsReceivedAsync(seekTime, token);
-                    await leaf.InvokeDirectMethodAsync(token);
-                },
-                async () =>
-                {
-                    await leaf.Close();
-                    await leaf.DeleteIdentityAsync(token);
-                });
+            Context.Current.LeafDeleteList.TryAdd(leafDeviceId, leaf);
+
+            DateTime seekTime = DateTime.Now;
+            await leaf.SendEventAsync(token);
+            await leaf.WaitForEventsReceivedAsync(seekTime, token);
+            await leaf.InvokeDirectMethodAsync(token);
 
             // Re-create the leaf with the same device ID, for our purposes this is
             // the equivalent of updating the SAS keys
@@ -109,19 +96,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.None<string>(),
                 this.device.NestedEdge.IsNestedEdge);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    DateTime seekTime = DateTime.Now;
-                    await leafUpdated.SendEventAsync(token);
-                    await leafUpdated.WaitForEventsReceivedAsync(seekTime, token);
-                    await leafUpdated.InvokeDirectMethodAsync(token);
-                },
-                async () =>
-                {
-                    await leafUpdated.Close();
-                    await leafUpdated.DeleteIdentityAsync(token);
-                });
+            seekTime = DateTime.Now;
+            await leafUpdated.SendEventAsync(token);
+            await leafUpdated.WaitForEventsReceivedAsync(seekTime, token);
+            await leafUpdated.InvokeDirectMethodAsync(token);
         }
 
         [Test]
@@ -155,40 +133,33 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.None<string>(),
                 Context.Current.NestedEdge);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    // Send a message from the leaf device
-                    DateTime seekTime = DateTime.Now;
-                    await leaf.SendEventAsync(token);
-                    Log.Verbose($"Sent message from {leafDeviceId}");
+            Context.Current.LeafDeleteList.TryAdd(leafDeviceId, leaf);
 
-                    // Verify that the message was received/resent by the relayer module on L4
-                    await Profiler.Run(
-                        () => this.IotHub.ReceiveEventsAsync(
-                            parentDeviceId,
-                            seekTime,
-                            data =>
-                            {
-                                data.SystemProperties.TryGetValue("iothub-connection-device-id", out object devId);
-                                data.SystemProperties.TryGetValue("iothub-connection-module-id", out object modId);
-                                data.Properties.TryGetValue("leaf-message-id", out object msgId);
+            // Send a message from the leaf device
+            DateTime seekTime = DateTime.Now;
+            await leaf.SendEventAsync(token);
+            Log.Verbose($"Sent message from {leafDeviceId}");
 
-                                Log.Verbose($"Received event for '{devId + "/" + modId}' with message ID '{msgId}'");
+            // Verify that the message was received/resent by the relayer module on L4
+            await Profiler.Run(
+                () => this.IotHub.ReceiveEventsAsync(
+                    parentDeviceId,
+                    seekTime,
+                    data =>
+                    {
+                        data.SystemProperties.TryGetValue("iothub-connection-device-id", out object devId);
+                        data.SystemProperties.TryGetValue("iothub-connection-module-id", out object modId);
+                        data.Properties.TryGetValue("leaf-message-id", out object msgId);
 
-                                return devId != null && devId.ToString().Equals(parentDeviceId)
-                                                     && modId.ToString().Equals(relayerModuleId);
-                            },
-                            token),
-                        "Received events from module '{Device}' on Event Hub '{EventHub}'",
-                        parentDeviceId + "/" + relayerModuleId,
-                        this.IotHub.EventHubName);
-                },
-                async () =>
-                {
-                    await leaf.Close();
-                    await leaf.DeleteIdentityAsync(token);
-                });
+                        Log.Verbose($"Received event for '{devId + "/" + modId}' with message ID '{msgId}'");
+
+                        return devId != null && devId.ToString().Equals(parentDeviceId)
+                                                && modId.ToString().Equals(relayerModuleId);
+                    },
+                    token),
+                "Received events from module '{Device}' on Event Hub '{EventHub}'",
+                parentDeviceId + "/" + relayerModuleId,
+                this.IotHub.EventHubName);
         }
 
         [Test]
@@ -226,18 +197,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.None<string>(),
                 this.device.NestedEdge.IsNestedEdge);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    DateTime seekTime = DateTime.Now;
-                    await leaf.SendEventAsync(token);
-                    await leaf.WaitForEventsReceivedAsync(seekTime, token);
-                    await leaf.InvokeDirectMethodAsync(token);
-                },
-                async () =>
-                {
-                    await leaf.DeleteIdentityAsync(token);
-                });
+            Context.Current.LeafDeleteList.TryAdd(leafDeviceId, leaf);
+
+            DateTime seekTime = DateTime.Now;
+            await leaf.SendEventAsync(token);
+            await leaf.WaitForEventsReceivedAsync(seekTime, token);
+            await leaf.InvokeDirectMethodAsync(token);
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     token,
                     Option.None<string>(),
                     this.device.NestedEdge.IsNestedEdge);
+
+                Context.Current.LeafDeleteList.TryAdd(leafDeviceId, leaf);
             }
             catch (Exception) when (!parentId.HasValue)
             {
@@ -58,18 +60,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             Assert.NotNull(leaf);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    DateTime seekTime = DateTime.Now;
-                    await leaf.SendEventAsync(token);
-                    await leaf.WaitForEventsReceivedAsync(seekTime, token);
-                    await leaf.InvokeDirectMethodAsync(token);
-                },
-                async () =>
-                {
-                    await leaf.DeleteIdentityAsync(token);
-                });
+            DateTime seekTime = DateTime.Now;
+            await leaf.SendEventAsync(token);
+            await leaf.WaitForEventsReceivedAsync(seekTime, token);
+            await leaf.InvokeDirectMethodAsync(token);
         }
 
         [Test]
@@ -112,6 +106,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     token,
                     Option.None<string>(),
                     this.device.NestedEdge.IsNestedEdge);
+
+                Context.Current.LeafDeleteList.TryAdd(leafDeviceId, leaf);
             }
             catch (Exception) when (!parentId.HasValue)
             {
@@ -125,19 +121,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             Assert.NotNull(leaf);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    DateTime seekTime = DateTime.Now;
-                    await leaf.SendEventAsync(token);
-                    await leaf.WaitForEventsReceivedAsync(seekTime, token);
-                    await leaf.InvokeDirectMethodAsync(token);
-                },
-                async () =>
-                {
-                    await leaf.DeleteIdentityAsync(token);
-                    await Task.CompletedTask;
-                });
+            DateTime seekTime = DateTime.Now;
+            await leaf.SendEventAsync(token);
+            await leaf.WaitForEventsReceivedAsync(seekTime, token);
+            await leaf.InvokeDirectMethodAsync(token);
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -48,18 +48,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.Some(TestModelId),
                 Context.Current.NestedEdge);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    DateTime seekTime = DateTime.Now;
-                    await leaf.SendEventAsync(token);
-                    await leaf.WaitForEventsReceivedAsync(seekTime, token);
-                    await this.ValidateIdentity(leafDeviceId, Option.None<string>(), TestModelId, token);
-                },
-                async () =>
-                {
-                    await leaf.DeleteIdentityAsync(token);
-                });
+            Context.Current.LeafDeleteList.TryAdd(leafDeviceId, leaf);
+
+            DateTime seekTime = DateTime.Now;
+            await leaf.SendEventAsync(token);
+            await leaf.WaitForEventsReceivedAsync(seekTime, token);
+            await this.ValidateIdentity(leafDeviceId, Option.None<string>(), TestModelId, token);
         }
 
         [TestCase(Protocol.Mqtt)]

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -124,6 +124,11 @@ namespace Microsoft.Azure.Devices.Edge.Test
                         await device.MaybeDeleteIdentityAsync(token);
                     }
 
+                    foreach (var leaf in Context.Current.LeafDeleteList.Values)
+                    {
+                        await leaf.DeleteIdentityAsync(token);
+                    }
+
                     // Remove packages installed by this run.
                     await this.daemon.UninstallAsync(token);
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
@@ -38,18 +38,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.None<string>(),
                 Context.Current.NestedEdge);
 
-            await TryFinally.DoAsync(
-                async () =>
-                {
-                    DateTime seekTime = DateTime.Now;
-                    await leaf.SendEventAsync(token);
-                    await leaf.WaitForEventsReceivedAsync(seekTime, token);
-                    await leaf.InvokeDirectMethodAsync(token);
-                },
-                async () =>
-                {
-                    await leaf.DeleteIdentityAsync(token);
-                });
+            Context.Current.LeafDeleteList.TryAdd(leafDeviceId, leaf);
+
+            DateTime seekTime = DateTime.Now;
+            await leaf.SendEventAsync(token);
+            await leaf.WaitForEventsReceivedAsync(seekTime, token);
+            await leaf.InvokeDirectMethodAsync(token);
         }
     }
 }


### PR DESCRIPTION
## Summary
This change updates end-to-end test cleanup so leaf device identities are deleted during suite teardown instead of inside each individual test cleanup path.

## Problem
In nested end-to-end scenarios, leaf identity deletion can be slow enough to consume the per-test timeout budget.  
For RouteMessageL3LeafToL4Module specifically, test execution could succeed functionally but still time out while deleting leaf identity in the test-finally block.

## What changed
- Added a dedicated leaf cleanup collection on test context.
- Registered created leaf devices in that collection at creation call sites across the E2E test suite.
- Removed per-test leaf identity deletion from test-finally blocks.
- Extended one-time teardown to delete all queued leaf identities using the teardown timeout token.

## Why this approach
- Aligns leaf cleanup behavior with existing edge device cleanup strategy.
- Keeps test timeout focused on test behavior, not cloud identity teardown latency.
- Reduces flakiness in nested topologies where cleanup can be slower.

## Scope
Applied to all current E2E test call sites that create leaf devices, including:
- Device tests
- Device with custom certificates tests
- Plug and Play tests
- X509 device tests

## Validation
- Verified that the nested end-to-end tests pass

## Expected impact
- Fewer false-negative timeouts caused by cleanup latency.
- No functional change to test assertions or message validation logic.
- Leaf identity deletion still occurs, but now under teardown timeout budget.

## Risk and mitigation
- Risk: if teardown is interrupted, leaf identities may remain temporarily.
- Mitigation: cleanup remains centralized and bounded by teardown timeout; behavior matches existing edge identity cleanup pattern.