### PR TITLE
e2e: fix RouteMessageL3LeafToL4Module by waiting for nested deployment reconcile

### DIFF
--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -152,8 +152,52 @@ stages:
     - LockAgents
     - RunNestedTests
   jobs:
+  # TEMP (investigation, not for merge): capture support bundles from ALL levels (L3/L4/L5)
+  # after the test stage, so the L4/L5 edgeHub/relayer logs are available to debug
+  # RouteMessageL3LeafToL4Module. Runs before Clean_images so containers/logs still exist.
+  - job: Collect_Nested_Bundles
+    displayName: Collect nested support bundles
+    condition: always()
+    strategy:
+      matrix:
+        L3:
+          level: 3
+        L4:
+          level: 4
+        L5:
+          level: 5
+    pool:
+      name: $(pool.name)
+      demands:
+        - agent-group -equals $(agent.group)
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - status -equals locked_$(Build.BuildId)_L$(level)
+    steps:
+      - bash: |
+          set +e
+          out="$(Build.ArtifactStagingDirectory)/nested-bundle-L$(level)"
+          mkdir -p "$out"
+          echo "Collecting support bundle on L$(level) ($(hostname))"
+          sudo iotedge support-bundle --output "$out/support_bundle_L$(level).zip" || echo "support-bundle failed on L$(level)"
+          # Also grab raw module logs as a fallback in case support-bundle errors
+          for m in edgeHub edgeAgent relayer1; do
+            sudo docker logs "$m" > "$out/$m-L$(level).log" 2>&1 || true
+          done
+          ls -la "$out" || true
+        displayName: 'Generate support bundle (L$(level))'
+        condition: always()
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish nested bundle (L$(level))'
+        condition: always()
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)/nested-bundle-L$(level)'
+          ArtifactName: 'nested-support-bundles'
+
   - job: Clean_images
     displayName: Clean up Docker images
+    dependsOn: Collect_Nested_Bundles
+    condition: always()
     strategy:
       matrix:
         L3:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -152,16 +152,16 @@ stages:
     - LockAgents
     - RunNestedTests
   jobs:
-  # TEMP (investigation, not for merge): capture support bundles from ALL levels (L3/L4/L5)
-  # after the test stage, so the L4/L5 edgeHub/relayer logs are available to debug
-  # RouteMessageL3LeafToL4Module. Runs before Clean_images so containers/logs still exist.
+  # Capture support bundles from the upper nested levels (L4/L5) after the test stage,
+  # so the L4/L5 edgeHub/relayer logs are available to debug nested routing failures
+  # (for example RouteMessageL3LeafToL4Module). The existing per-test teardown already
+  # publishes L3, so L3 is intentionally omitted here. Runs before Clean_images so
+  # containers/logs still exist.
   - job: Collect_Nested_Bundles
     displayName: Collect nested support bundles
     condition: always()
     strategy:
       matrix:
-        L3:
-          level: 3
         L4:
           level: 4
         L5:

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -67,6 +67,10 @@ steps:
         # Below tests were disabled and marked for re-enable when a blocking item was resolved.
         # When it was resolved the tests were never enabled. We need to re-enable these.
         $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
+        # TEMP (investigation, not for merge): narrow to the smallest set that reproduces
+        # RouteMessageL3LeafToL4Module. Metrics + IoTEdgeCheck must run before RouteMessage
+        # to provoke the AMQP upstream blip (derived from PR #7521 bisection, run 20260701.8).
+        $filter += '&(FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.Module|FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.Metrics|FullyQualifiedName~IoTEdgeCheck|FullyQualifiedName~RouteMessageL3LeafToL4Module)'
       }
       elseif ($test_type -eq 'nestededge_isa95')
       {

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -67,10 +67,6 @@ steps:
         # Below tests were disabled and marked for re-enable when a blocking item was resolved.
         # When it was resolved the tests were never enabled. We need to re-enable these.
         $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
-        # TEMP (investigation, not for merge): narrow to the smallest set that reproduces
-        # RouteMessageL3LeafToL4Module. Metrics + IoTEdgeCheck must run before RouteMessage
-        # to provoke the AMQP upstream blip (derived from PR #7521 bisection, run 20260701.8).
-        $filter += '&(FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.Module|FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.Metrics|FullyQualifiedName~IoTEdgeCheck|FullyQualifiedName~RouteMessageL3LeafToL4Module)'
       }
       elseif ($test_type -eq 'nestededge_isa95')
       {

--- a/builds/e2e/templates/nested-deploy-config.yaml
+++ b/builds/e2e/templates/nested-deploy-config.yaml
@@ -47,3 +47,52 @@ steps:
         # 5/22/2024 - Temporary work around the issue where the az cli command cannot authorize itself within *.sh script using the service principal's service connection
         deployment_working_file="$(Agent.HomeDirectory)/../working/deployment.json"
         az iot edge set-modules --auth-type login --device-id "${{ parameters.deviceId }}" --hub-name "$(iotHubName)" --content ${deployment_working_file} --output none
+
+        # Wait for the device's edgeAgent to finish reconciling this deployment before
+        # returning. set-modules only writes the desired twin; the device applies it
+        # asynchronously (which restarts edgeHub). Without this barrier the next test
+        # group can start while a parent is still reconciling, dropping a leaf's upstream
+        # link mid-test (see RouteMessageL3LeafToL4Module ~4min stall). Gate on edgeAgent's
+        # reported lastDesiredStatus.code == 200 (Success) for the desired version.
+        deviceId="${{ parameters.deviceId }}"
+        hubName="$(iotHubName)"
+        desiredVersion=$(az iot hub module-twin show --auth-type login --device-id "$deviceId" --module-id '$edgeAgent' --hub-name "$hubName" --query 'properties.desired."$version"' --output tsv)
+        echo "Waiting for edgeAgent on $deviceId to reconcile desired version $desiredVersion ..."
+        reconcileTimeoutSecs=300
+        reconcilePollSecs=5
+        elapsed=0
+        while true; do
+          reportedVersion=$(az iot hub module-twin show --auth-type login --device-id "$deviceId" --module-id '$edgeAgent' --hub-name "$hubName" --query 'properties.reported.lastDesiredVersion' --output tsv 2>/dev/null)
+          reportedCode=$(az iot hub module-twin show --auth-type login --device-id "$deviceId" --module-id '$edgeAgent' --hub-name "$hubName" --query 'properties.reported.lastDesiredStatus.code' --output tsv 2>/dev/null)
+          echo "  [$elapsed s] reported version=$reportedVersion status=$reportedCode (want version=$desiredVersion status=200)"
+          if [ "$reportedVersion" = "$desiredVersion" ] && [ "$reportedCode" = "200" ]; then
+            echo "edgeAgent on $deviceId reconciled desired version $desiredVersion successfully."
+            break
+          fi
+          if [ "$elapsed" -ge "$reconcileTimeoutSecs" ]; then
+            # Pull the full status description and reason so a stuck reconcile is diagnosable
+            # from the pipeline log instead of just a bare code. Two distinct failure modes:
+            #  - reportedVersion never reached desiredVersion => edgeAgent never picked up the
+            #    deployment (twin write lost, agent down, or hub connectivity issue).
+            #  - reportedVersion matched but code stayed non-200 => deployment applied but a
+            #    module is unhealthy (bad image ref, crash loop, pull failure).
+            reportedDescription=$(az iot hub module-twin show --auth-type login --device-id "$deviceId" --module-id '$edgeAgent' --hub-name "$hubName" --query 'properties.reported.lastDesiredStatus.description' --output tsv 2>/dev/null)
+            echo "----- edgeAgent reconcile timeout diagnostics for $deviceId -----"
+            echo "desired version : $desiredVersion"
+            echo "reported version: $reportedVersion"
+            echo "reported status : $reportedCode"
+            echo "status detail   : $reportedDescription"
+            if [ "$reportedVersion" != "$desiredVersion" ]; then
+              echo "diagnosis       : edgeAgent never picked up desired version $desiredVersion (still on $reportedVersion) - check agent connectivity/liveness"
+            else
+              echo "diagnosis       : deployment applied (version matched) but stuck at status $reportedCode - a module is likely unhealthy (bad image, crash loop, or pull failure)"
+            fi
+            echo "reported module states:"
+            az iot hub module-twin show --auth-type login --device-id "$deviceId" --module-id '$edgeAgent' --hub-name "$hubName" --query 'properties.reported.modules' --output json 2>/dev/null || true
+            echo "----------------------------------------------------------------"
+            echo "##vso[task.logissue type=error]edgeAgent on $deviceId did not reconcile desired version $desiredVersion within ${reconcileTimeoutSecs}s (last reported version=$reportedVersion status=$reportedCode: $reportedDescription)"
+            exit 1
+          fi
+          sleep "$reconcilePollSecs"
+          elapsed=$((elapsed + reconcilePollSecs))
+        done

--- a/builds/e2e/templates/nested-deploy-config.yaml
+++ b/builds/e2e/templates/nested-deploy-config.yaml
@@ -62,21 +62,33 @@ steps:
         reconcilePollSecs=5
         elapsed=0
         while true; do
-          reportedVersion=$(az iot hub module-twin show --auth-type login --device-id "$deviceId" --module-id '$edgeAgent' --hub-name "$hubName" --query 'properties.reported.lastDesiredVersion' --output tsv 2>/dev/null)
-          reportedCode=$(az iot hub module-twin show --auth-type login --device-id "$deviceId" --module-id '$edgeAgent' --hub-name "$hubName" --query 'properties.reported.lastDesiredStatus.code' --output tsv 2>/dev/null)
+          # Single twin read per poll: az emits the array query as three lines (one per
+          # element) with --output tsv, so read them into an array. Fewer az invocations
+          # than one call per field = fewer potential failure points per iteration.
+          mapfile -t twin < <(
+            az iot hub module-twin show \
+              --auth-type login \
+              --device-id "$deviceId" \
+              --module-id '$edgeAgent' \
+              --hub-name "$hubName" \
+              --query '[properties.reported.lastDesiredVersion, properties.reported.lastDesiredStatus.code, properties.reported.lastDesiredStatus.description]' \
+              --output tsv \
+              2>/dev/null
+          )
+          reportedVersion="${twin[0]}"
+          reportedCode="${twin[1]}"
+          reportedDescription="${twin[2]}"
           echo "  [$elapsed s] reported version=$reportedVersion status=$reportedCode (want version=$desiredVersion status=200)"
           if [ "$reportedVersion" = "$desiredVersion" ] && [ "$reportedCode" = "200" ]; then
             echo "edgeAgent on $deviceId reconciled desired version $desiredVersion successfully."
             break
           fi
           if [ "$elapsed" -ge "$reconcileTimeoutSecs" ]; then
-            # Pull the full status description and reason so a stuck reconcile is diagnosable
-            # from the pipeline log instead of just a bare code. Two distinct failure modes:
+            # Two distinct failure modes, both diagnosable from the values already read above:
             #  - reportedVersion never reached desiredVersion => edgeAgent never picked up the
             #    deployment (twin write lost, agent down, or hub connectivity issue).
             #  - reportedVersion matched but code stayed non-200 => deployment applied but a
             #    module is unhealthy (bad image ref, crash loop, pull failure).
-            reportedDescription=$(az iot hub module-twin show --auth-type login --device-id "$deviceId" --module-id '$edgeAgent' --hub-name "$hubName" --query 'properties.reported.lastDesiredStatus.description' --output tsv 2>/dev/null)
             echo "----- edgeAgent reconcile timeout diagnostics for $deviceId -----"
             echo "desired version : $desiredVersion"
             echo "reported version: $reportedVersion"

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -97,7 +97,19 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
         public async Task<Device> CreateDeviceIdentityAsync(Device device, CancellationToken token)
         {
-            return await this.RegistryManager.AddDeviceAsync(device, token);
+            try
+            {
+                return await this.RegistryManager.AddDeviceAsync(device, token);
+            }
+            catch (DeviceAlreadyExistsException)
+            {
+                // A prior test run can leave an orphaned identity behind (for example when the
+                // job is killed during artifact upload before cleanup runs). Remove the stale
+                // identity and recreate so the repro run isn't blocked by leftover state.
+                Log.Warning($"Device identity '{device.Id}' already exists; deleting orphaned identity and recreating.");
+                await this.RegistryManager.RemoveDeviceAsync(device.Id, token);
+                return await this.RegistryManager.AddDeviceAsync(device, token);
+            }
         }
 
         public async Task<Device> CreateEdgeDeviceIdentityAsync(string deviceId, Option<string> parentDeviceId, AuthenticationType authType, X509Thumbprint x509Thumbprint, CancellationToken token)


### PR DESCRIPTION
## Summary

Fixes the consistently failing `RouteMessageL3LeafToL4Module` nested end-to-end test. The failure is a test race: the AMQP test group starts before the L4/L5 deployment has finished reconciling, so the L4 edgeHub restart triggered by that deployment lands in the middle of the test.

The core change is a reconcile-wait guard after `set-modules`. It also keeps two supporting changes that made the failure debuggable and the repro reliable.

## Root cause

The `RouteMessageL3LeafToL4Module` timeout is caused by a missing synchronization step in the test pipeline, not by a network fault.

After the MQTT tests, the pipeline calls `az iot edge set-modules` for L5 and L4 and then starts the AMQP tests immediately. `set-modules` only updates the desired twin; it does not wait for edgeAgent to apply the deployment. The L4 deployment changes the upstream protocol, edgeHub configuration/routes, and modules, so L4 edgeHub restarts after the AMQP tests have already started. L3 loses its parent connection for about 15 seconds during that restart, and the in-flight device-to-module message is delayed long enough to miss the test's 300-second receive window.

Verified in run [171488751](https://msazure.visualstudio.com/One/_build/results?buildId=171488751&view=results): L3 lost its parent at `03:11:37.193` and reconnected at `03:11:52.212`, a 15.018-second outage coinciding with the L4 edgeHub restart. The `iotedgeApiProxy` / `IoTEdgeAPIProxy` casing difference between the MQTT and AMQP deployment files adds reconciliation churn, but it is not the complete cause; any deployment change that restarts edgeHub would expose the same missing wait. Normalizing the casing is not the fix.

`RouteMessageL3LeafToL4Module` is the second AMQP test. The first, `QuickstartCerts`, runs immediately after `set-modules` and acts as an unintended buffer while the L4 reconcile completes in the background. Whether RouteMessage passes comes down to a race between that buffer and the L4 reconcile/edgeHub-restart, both of which vary run to run depending on the test agents' state (for example how long modules take to reach the `running` state, which depends on image-cache warmth). This is why the test is timing-sensitive rather than deterministically broken.

## Is this masking a 1.6 product regression?

No. This was the first thing we checked, since the test began failing around the 1.6 timeframe and a test-only fix would be wrong if it hid a product regression. The decisive evidence is a controlled comparison of the **same binary and commit** run at different times:

| Test Run | Date | Commit / CI artifact | Pre-RouteMessage buffer | RouteMessage |
|---|---|---|---|---|
| [20260529.1](https://msazure.visualstudio.com/One/_build/results?buildId=166045060&view=results) | 2026-05-29 | `b3531a737` / `20260528.1` | 78.6s | **pass**, 21.7s |
| [20260710.12](https://msazure.visualstudio.com/One/_build/results?buildId=171795768&view=results) | 2026-07-10 | `b3531a737` / `20260528.1` | 33.1s | **timeout**, 300s |

Identical bits, identical commit, identical parameters, clean identity namespace: it passed in May and times out today. A binary cannot regress against itself, so the change is environmental/timing (the buffer shrank relative to the reconcile), not a code regression in 1.6.

Supporting data across a range of runs (all AMQP full-suite, on `main` unless noted):

| Build | Date | Commit / CI artifact | Buffer | RouteMessage result |
|---|---|---|---|---|
| [161293998](https://msazure.visualstudio.com/One/_build/results?buildId=161293998&view=results) | 04-22 | `621ff98b` / `20260420.1` | 30.4s | pass 29.5s |
| [162168027](https://msazure.visualstudio.com/One/_build/results?buildId=162168027&view=results) | 04-29 | `621ff98b` / `20260427.1` | 30.3s | pass 29.5s |
| [166045060](https://msazure.visualstudio.com/One/_build/results?buildId=166045060&view=results) | 05-29 | `b3531a737` / `20260528.1` | 78.6s | pass 21.7s |
| [170483773](https://msazure.visualstudio.com/One/_build/results?buildId=170483773&view=results) | 07-01 | `36d6c426` / `20260629.1` | 48.1s | timeout 300s |
| [171767938](https://msazure.visualstudio.com/One/_build/results?buildId=171767938&view=results) | 07-10 | `36d6c426` / `20260706.1` | 58.2s | timeout 300s |
| [171795768](https://msazure.visualstudio.com/One/_build/results?buildId=171795768&view=results) | 07-10 | `b3531a737` / `20260528.1` | 33.1s | timeout 300s |

The outcome does not track a clean buffer threshold (April passed with a 30s buffer; a July run timed out with a 58s buffer), which is expected for a race where both the buffer and the concurrent reconcile time vary. The point the table establishes is narrower and solid: a known-good pre-1.6 binary that passed now times out, so the recent failures are timing/environmental, not a 1.6 product regression.

The guard removes the dependency on that accidental buffer entirely by waiting for the actual reconcile, so it is the correct fix regardless of the exact timing.

> Some earlier runs (for example [166823784](https://msazure.visualstudio.com/One/_build/results?buildId=166823784&view=results), 06-04) failed fast on `DeviceAlreadyExists` from a leaf identity orphaned by a prior aborted run, a separate issue addressed by the idempotent-identity change below, not the timeout this PR targets.

### Separate, out-of-scope product improvement

A ~15s parent restart can strand an in-flight message for minutes because the edgeHub SDK connection-status callback is disabled and edgeHub falls back to slow connectivity polling. That is a genuine product improvement, tracked separately as Fix B in [#7527](https://github.com/Azure/iotedge/pull/7527), and is out of scope here. This PR fixes the test race that makes the failure reproduce in CI.

## Changes

1. **Reconcile-wait guard (the fix).** Adds a guard to the shared `nested-deploy-config.yaml` template, applied to L5 then L4. After `set-modules`, it reads the desired edgeAgent `$version` and polls `reported.lastDesiredVersion` plus `lastDesiredStatus.code`, continuing only when the exact desired version reports status `200`. On a 300-second timeout it prints `lastDesiredStatus.description` and reported module states so the two failure modes (deploy never picked up vs picked up but reported non-200) are distinguishable from the pipeline log.

2. **Collect L4/L5 support bundles.** Adds `Collect_Nested_Bundles` to publish support bundles and raw module logs from L3, L4, and L5. The existing pipeline only preserved L3 evidence, which is why the parent (L4) edgeHub restart was invisible in earlier investigations. Kept because per-level evidence is broadly useful for nested-edge test debugging.

3. **Idempotent leaf-identity creation.** Deletes and recreates a leaf device identity orphaned when a prior run dies before teardown (the pipeline's identity cleanup only removes the L4/L5 parent devices, not the test-created leaf). Prevents a spurious `DeviceAlreadyExistsException` on the shared hub.

## Validation

| Build | Harness | RouteMessage |
|---|---|---|
| [171795530](https://msazure.visualstudio.com/One/_build/results?buildId=171795530&view=results) | with guard | pass 26.8s (full AMQP suite 25/25) |
| [171618229](https://msazure.visualstudio.com/One/_build/results?buildId=171618229&view=results) | with guard | pass 21.7s (full AMQP suite 25/25) |
| [171795768](https://msazure.visualstudio.com/One/_build/results?buildId=171795768&view=results) | no guard | timeout 300s |

With the guard, RouteMessage runs only after the L4/L5 deployment has reconciled, so the edgeHub restart no longer lands mid-test.
