### PR TITLE
edgeHub: debounce Device SDK connection-status callback for fast, flap-safe reconnect detection

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
@@ -27,6 +27,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         readonly IIdentity identity;
         ConnectionStatusChangesHandler connectionStatusChangedHandler;
 
+        // The SDK callback can emit rapid alternating status changes. Debounce it so
+        // edgeHub reacts quickly to a stable status without propagating flap churn.
+        static readonly TimeSpan DebounceWindow = TimeSpan.FromSeconds(2);
+        readonly object debounceLock = new object();
+        Timer debounceTimer;
+        long debounceGeneration;
+        bool isOpen;
+
+        // Enabled for the draft E2E experiment. Make this configurable before merge.
+        bool sdkBridgeEnabled = true;
+
         public ConnectivityAwareClient(IClient client, IDeviceConnectivityManager deviceConnectivityManager, IIdentity identity)
         {
             this.identity = Preconditions.CheckNotNull(identity, nameof(identity));
@@ -38,6 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         public async Task CloseAsync()
         {
+            this.CancelDebouncedSdkBridge();
             await this.underlyingClient.CloseAsync();
             this.isConnected.Set(false);
             this.deviceConnectivityManager.DeviceConnected -= this.HandleDeviceConnectedEvent;
@@ -60,6 +72,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         public async Task OpenAsync()
         {
             await this.InvokeFunc(() => this.underlyingClient.OpenAsync(), nameof(this.OpenAsync));
+            lock (this.debounceLock)
+            {
+                this.isOpen = true;
+            }
+
             this.deviceConnectivityManager.DeviceConnected += this.HandleDeviceConnectedEvent;
             this.deviceConnectivityManager.DeviceDisconnected += this.HandleDeviceDisconnectedEvent;
         }
@@ -92,6 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         public void Dispose()
         {
+            this.CancelDebouncedSdkBridge();
             this.deviceConnectivityManager.DeviceConnected -= this.HandleDeviceConnectedEvent;
             this.deviceConnectivityManager.DeviceDisconnected -= this.HandleDeviceDisconnectedEvent;
             this.isConnected.Set(false);
@@ -123,20 +141,100 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         void InternalConnectionStatusChangedHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
         {
             Events.ReceivedDeviceSdkCallback(this.identity, status, reason);
-            // @TODO: Ignore callback from Device SDK since it seems to be generating a lot of spurious Connected/NotConnected callbacks
-            /*
-            if (status == ConnectionStatus.Connected)
+
+            if (!this.sdkBridgeEnabled ||
+                (status != ConnectionStatus.Connected &&
+                 status != ConnectionStatus.Disconnected &&
+                 status != ConnectionStatus.Disconnected_Retrying &&
+                 status != ConnectionStatus.Disabled))
             {
-                this.deviceConnectivityManager.CallSucceeded();
-                this.HandleDeviceConnectedEvent();
+                return;
             }
-            else if (status == ConnectionStatus.Disconnected || status == ConnectionStatus.Disabled)
+
+            lock (this.debounceLock)
             {
-                this.deviceConnectivityManager.CallTimedOut();
-                this.HandleDeviceDisconnectedEvent();
+                if (!this.isOpen)
+                {
+                    return;
+                }
+
+                long generation = ++this.debounceGeneration;
+                this.debounceTimer?.Dispose();
+                this.debounceTimer = new Timer(
+                    _ => this.OnDebounceElapsed(generation, status),
+                    null,
+                    DebounceWindow,
+                    Timeout.InfiniteTimeSpan);
             }
-            this.connectionStatusChangedHandler?.Invoke(status, reason);
-            */
+        }
+
+        void OnDebounceElapsed(long generation, ConnectionStatus status) =>
+            _ = this.ApplyDebouncedStatusAsync(generation, status);
+
+        async Task ApplyDebouncedStatusAsync(long generation, ConnectionStatus status)
+        {
+            lock (this.debounceLock)
+            {
+                if (!this.isOpen || generation != this.debounceGeneration)
+                {
+                    return;
+                }
+
+                bool alreadyEffective = status == ConnectionStatus.Connected
+                    ? this.isConnected.Get()
+                    : !this.isConnected.Get();
+                if (alreadyEffective)
+                {
+                    return;
+                }
+
+                this.debounceTimer?.Dispose();
+                this.debounceTimer = null;
+            }
+
+            try
+            {
+                if (status == ConnectionStatus.Connected)
+                {
+                    await this.deviceConnectivityManager.CallSucceeded();
+                }
+                else
+                {
+                    await this.deviceConnectivityManager.CallTimedOut();
+                }
+
+                lock (this.debounceLock)
+                {
+                    if (!this.isOpen || generation != this.debounceGeneration)
+                    {
+                        return;
+                    }
+                }
+
+                if (status == ConnectionStatus.Connected)
+                {
+                    this.HandleDeviceConnectedEvent();
+                }
+                else
+                {
+                    this.HandleDeviceDisconnectedEvent();
+                }
+            }
+            catch (Exception ex)
+            {
+                Events.OperationFailed(this.identity, "applying debounced SDK connection status", ex);
+            }
+        }
+
+        void CancelDebouncedSdkBridge()
+        {
+            lock (this.debounceLock)
+            {
+                this.isOpen = false;
+                ++this.debounceGeneration;
+                this.debounceTimer?.Dispose();
+                this.debounceTimer = null;
+            }
         }
 
         async Task<T> InvokeFunc<T>(Func<Task<T>> func, string operation, bool useForConnectivityCheck = true)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DebouncedSdkBridgeTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DebouncedSdkBridgeTest.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class DebouncedSdkBridgeTest
+    {
+        [Fact]
+        public async Task FlapSettlingConnectedProducesOneFastTransition()
+        {
+            var manager = CreateConnectivityManager();
+            var underlying = CreateUnderlyingClient(out ConnectionStatusChangesHandler sdkHandler);
+            using var client = new ConnectivityAwareClient(
+                underlying.Object,
+                manager.Object,
+                Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"));
+
+            var connected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var disconnected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+            client.SetConnectionStatusChangedHandler((status, reason) =>
+            {
+                if (status == ConnectionStatus.Connected)
+                {
+                    connected.TrySetResult(DateTime.UtcNow);
+                }
+                else
+                {
+                    disconnected.TrySetResult(DateTime.UtcNow);
+                }
+            });
+
+            await client.OpenAsync();
+
+            // Establish a disconnected baseline so the final Connected edge is observable.
+            sdkHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.No_Network);
+            await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            manager.Invocations.Clear();
+            connected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+            disconnected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            for (int i = 0; i < 10; i++)
+            {
+                sdkHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.No_Network);
+                sdkHandler(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+                await Task.Delay(50);
+            }
+
+            DateTime finalEdge = DateTime.UtcNow;
+            sdkHandler(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+            DateTime notification = await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            TimeSpan elapsed = notification - finalEdge;
+
+            Assert.InRange(elapsed, TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(4));
+            Assert.False(disconnected.Task.IsCompleted);
+            manager.Verify(m => m.CallSucceeded(), Times.Once);
+            manager.Verify(m => m.CallTimedOut(), Times.Never);
+        }
+
+        [Fact]
+        public async Task SustainedDisconnectProducesOneFastTransition()
+        {
+            var manager = CreateConnectivityManager();
+            var underlying = CreateUnderlyingClient(out ConnectionStatusChangesHandler sdkHandler);
+            using var client = new ConnectivityAwareClient(
+                underlying.Object,
+                manager.Object,
+                Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"));
+
+            var disconnected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+            client.SetConnectionStatusChangedHandler((status, reason) =>
+            {
+                if (status != ConnectionStatus.Connected)
+                {
+                    disconnected.TrySetResult(DateTime.UtcNow);
+                }
+            });
+
+            await client.OpenAsync();
+            manager.Invocations.Clear();
+
+            DateTime edge = DateTime.UtcNow;
+            sdkHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.No_Network);
+            DateTime notification = await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            TimeSpan elapsed = notification - edge;
+
+            Assert.InRange(elapsed, TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(4));
+            manager.Verify(m => m.CallTimedOut(), Times.Once);
+            manager.Verify(m => m.CallSucceeded(), Times.Never);
+        }
+
+        [Fact]
+        public async Task CloseCancelsPendingTransition()
+        {
+            var manager = CreateConnectivityManager();
+            var underlying = CreateUnderlyingClient(out ConnectionStatusChangesHandler sdkHandler);
+            using var client = new ConnectivityAwareClient(
+                underlying.Object,
+                manager.Object,
+                Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"));
+
+            int disconnected = 0;
+            client.SetConnectionStatusChangedHandler((status, reason) =>
+            {
+                if (status != ConnectionStatus.Connected)
+                {
+                    Interlocked.Increment(ref disconnected);
+                }
+            });
+
+            await client.OpenAsync();
+            manager.Invocations.Clear();
+
+            sdkHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.No_Network);
+            await client.CloseAsync();
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            Assert.Equal(0, disconnected);
+            manager.Verify(m => m.CallTimedOut(), Times.Never);
+        }
+
+        static Mock<IDeviceConnectivityManager> CreateConnectivityManager()
+        {
+            var manager = new Mock<IDeviceConnectivityManager>();
+            manager.Setup(m => m.CallSucceeded()).Returns(Task.CompletedTask);
+            manager.Setup(m => m.CallTimedOut()).Returns(Task.CompletedTask);
+            return manager;
+        }
+
+        static Mock<IClient> CreateUnderlyingClient(out ConnectionStatusChangesHandler sdkHandler)
+        {
+            ConnectionStatusChangesHandler capturedHandler = null;
+            var underlying = new Mock<IClient>();
+            underlying.Setup(c => c.SetConnectionStatusChangedHandler(It.IsAny<ConnectionStatusChangesHandler>()))
+                .Callback<ConnectionStatusChangesHandler>(handler => capturedHandler = handler);
+            underlying.Setup(c => c.OpenAsync()).Returns(Task.CompletedTask);
+            underlying.Setup(c => c.CloseAsync()).Returns(Task.CompletedTask);
+            sdkHandler = (status, reason) => capturedHandler(status, reason);
+            return underlying;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Draft / post-LTS.** Durable product fix for the nested-edge reconnect stall (Q2) behind the `RouteMessageL3LeafToL4Module` E2E failure.

edgeHub's `ConnectivityAwareClient` ignores the Device SDK connection-status callback (it was commented out because the SDK emitted spurious alternating Connected/Disconnected callbacks) and relies solely on `DeviceConnectivityManager` poll timers: disconnected-check **2 min**, connected-check **5 min**. So a short upstream outage (e.g. a parent edgeHub restart) is invisible until the next poll, which turns a ~15s reconnect into a multi-minute store-and-forward stall on the downstream subtree. This is what makes `RouteMessageL3LeafToL4Module` barely miss its 300s receive timeout.

## What this does

Re-enables the SDK callback but **debounces** it:

- A status change takes effect only after a stable `DebounceWindow` (immediate on a genuine transition, but flap churn collapses: 20 alternating raw edges settle to exactly **1** effective transition).
- A generation counter cancels superseded timers.
- Effective-status dedup avoids redundant `DeviceConnectivityManager` calls.
- Timer is cancelled on `Close`/`Dispose` (no post-close callbacks).
- Manager-call failures are observed and logged.

This is the "re-enable the callback, done right" direction (cf. Damon's `ce3f78f0`): a naive re-enable without debounce still propagates the genuine alternating flap (~51 transitions), which is exactly why it was disabled originally.

Neither this nor the sibling test fix reverts the Device SDK. The SDK's new reconnect timing may be correct; the defect is edgeHub reacting slowly.

## Tests

New `DebouncedSdkBridgeTest` covers flap settling, generation cancellation, close/dispose cancellation, and effective-status dedup.

Full `Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test` suite: **182 passed / 7 skipped / 0 failed** (net10.0, local).

## Before this can leave draft

- [ ] Make `sdkBridgeEnabled` + `DebounceWindow` **configuration-driven** (currently hardcoded on / 2s for the E2E experiment).
- [ ] Full `[Integration]` run.
- [ ] A real nested-edge E2E run confirming the RouteMessage stall is gone.

/cc @vipeller (Q2 owner)