### PR TITLE
edgeHub: resume store-and-forward promptly after reconnect

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
@@ -27,6 +27,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         readonly IIdentity identity;
         ConnectionStatusChangesHandler connectionStatusChangedHandler;
 
+        // The SDK callback can emit rapid alternating status changes. Debounce it so
+        // edgeHub reacts quickly to a stable status without propagating flap churn.
+        static readonly TimeSpan DebounceWindow = TimeSpan.FromSeconds(2);
+        readonly object debounceLock = new object();
+        Timer debounceTimer;
+        long debounceGeneration;
+        bool isOpen;
+
+        // Enabled for the draft E2E experiment. Make this configurable before merge.
+        bool sdkBridgeEnabled = true;
+
         public ConnectivityAwareClient(IClient client, IDeviceConnectivityManager deviceConnectivityManager, IIdentity identity)
         {
             this.identity = Preconditions.CheckNotNull(identity, nameof(identity));
@@ -38,6 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         public async Task CloseAsync()
         {
+            this.CancelDebouncedSdkBridge();
             await this.underlyingClient.CloseAsync();
             this.isConnected.Set(false);
             this.deviceConnectivityManager.DeviceConnected -= this.HandleDeviceConnectedEvent;
@@ -60,6 +72,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         public async Task OpenAsync()
         {
             await this.InvokeFunc(() => this.underlyingClient.OpenAsync(), nameof(this.OpenAsync));
+            lock (this.debounceLock)
+            {
+                this.isOpen = true;
+            }
+
             this.deviceConnectivityManager.DeviceConnected += this.HandleDeviceConnectedEvent;
             this.deviceConnectivityManager.DeviceDisconnected += this.HandleDeviceDisconnectedEvent;
         }
@@ -92,6 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         public void Dispose()
         {
+            this.CancelDebouncedSdkBridge();
             this.deviceConnectivityManager.DeviceConnected -= this.HandleDeviceConnectedEvent;
             this.deviceConnectivityManager.DeviceDisconnected -= this.HandleDeviceDisconnectedEvent;
             this.isConnected.Set(false);
@@ -123,20 +141,100 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         void InternalConnectionStatusChangedHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
         {
             Events.ReceivedDeviceSdkCallback(this.identity, status, reason);
-            // @TODO: Ignore callback from Device SDK since it seems to be generating a lot of spurious Connected/NotConnected callbacks
-            /*
-            if (status == ConnectionStatus.Connected)
+
+            if (!this.sdkBridgeEnabled ||
+                (status != ConnectionStatus.Connected &&
+                 status != ConnectionStatus.Disconnected &&
+                 status != ConnectionStatus.Disconnected_Retrying &&
+                 status != ConnectionStatus.Disabled))
             {
-                this.deviceConnectivityManager.CallSucceeded();
-                this.HandleDeviceConnectedEvent();
+                return;
             }
-            else if (status == ConnectionStatus.Disconnected || status == ConnectionStatus.Disabled)
+
+            lock (this.debounceLock)
             {
-                this.deviceConnectivityManager.CallTimedOut();
-                this.HandleDeviceDisconnectedEvent();
+                if (!this.isOpen)
+                {
+                    return;
+                }
+
+                long generation = ++this.debounceGeneration;
+                this.debounceTimer?.Dispose();
+                this.debounceTimer = new Timer(
+                    _ => this.OnDebounceElapsed(generation, status),
+                    null,
+                    DebounceWindow,
+                    Timeout.InfiniteTimeSpan);
             }
-            this.connectionStatusChangedHandler?.Invoke(status, reason);
-            */
+        }
+
+        void OnDebounceElapsed(long generation, ConnectionStatus status) =>
+            _ = this.ApplyDebouncedStatusAsync(generation, status);
+
+        async Task ApplyDebouncedStatusAsync(long generation, ConnectionStatus status)
+        {
+            lock (this.debounceLock)
+            {
+                if (!this.isOpen || generation != this.debounceGeneration)
+                {
+                    return;
+                }
+
+                bool alreadyEffective = status == ConnectionStatus.Connected
+                    ? this.isConnected.Get()
+                    : !this.isConnected.Get();
+                if (alreadyEffective)
+                {
+                    return;
+                }
+
+                this.debounceTimer?.Dispose();
+                this.debounceTimer = null;
+            }
+
+            try
+            {
+                if (status == ConnectionStatus.Connected)
+                {
+                    await this.deviceConnectivityManager.CallSucceeded();
+                }
+                else
+                {
+                    await this.deviceConnectivityManager.CallTimedOut();
+                }
+
+                lock (this.debounceLock)
+                {
+                    if (!this.isOpen || generation != this.debounceGeneration)
+                    {
+                        return;
+                    }
+                }
+
+                if (status == ConnectionStatus.Connected)
+                {
+                    this.HandleDeviceConnectedEvent();
+                }
+                else
+                {
+                    this.HandleDeviceDisconnectedEvent();
+                }
+            }
+            catch (Exception ex)
+            {
+                Events.OperationFailed(this.identity, "applying debounced SDK connection status", ex);
+            }
+        }
+
+        void CancelDebouncedSdkBridge()
+        {
+            lock (this.debounceLock)
+            {
+                this.isOpen = false;
+                ++this.debounceGeneration;
+                this.debounceTimer?.Dispose();
+                this.debounceTimer = null;
+            }
         }
 
         async Task<T> InvokeFunc<T>(Func<Task<T>> func, string operation, bool useForConnectivityCheck = true)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         public event EventHandler DeviceDisconnected;
 
+        public event EventHandler ConnectivityRecovered;
+
         enum State
         {
             Connected,
@@ -140,6 +142,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         void OnConnected()
         {
             Events.OnConnected();
+            this.ConnectivityRecovered?.Invoke(this, EventArgs.Empty);
             this.connectedTimer.Start();
         }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceConnectivityManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceConnectivityManager.cs
@@ -10,6 +10,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         event EventHandler DeviceDisconnected;
 
+        // Unlike DeviceConnected, this event also fires when a short outage recovers
+        // from the intermediate Trying state without first reaching Disconnected.
+        event EventHandler ConnectivityRecovered;
+
         Task CallSucceeded();
 
         Task CallTimedOut();

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceConnectivityManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceConnectivityManager.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             remove { }
         }
 
+        public event EventHandler ConnectivityRecovered
+        {
+            add { }
+            remove { }
+        }
+
         public Task CallSucceeded() => Task.CompletedTask;
 
         public Task CallTimedOut() => Task.CompletedTask;

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -430,7 +430,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         {
                             var endpointExecutorConfig = c.Resolve<EndpointExecutorConfig>();
                             var messageStore = await c.Resolve<Task<IMessageStore>>();
-                            IEndpointExecutorFactory endpointExecutorFactory = new StoringAsyncEndpointExecutorFactory(endpointExecutorConfig, new AsyncEndpointExecutorOptions(10, TimeSpan.FromSeconds(10)), messageStore);
+                            // A recovered connection can land in the middle of an endpoint retry
+                            // backoff (up to 60 seconds). Wake parked FSMs instead of waiting out
+                            // the remaining backoff before store-and-forward resumes.
+                            var retrySignal = new EndpointExecutorRetrySignal();
+                            c.Resolve<IDeviceConnectivityManager>().ConnectivityRecovered += (_, __) => retrySignal.RequestRetry();
+                            IEndpointExecutorFactory endpointExecutorFactory = new StoringAsyncEndpointExecutorFactory(
+                                endpointExecutorConfig,
+                                new AsyncEndpointExecutorOptions(10, TimeSpan.FromSeconds(10)),
+                                messageStore,
+                                retrySignal);
                             return endpointExecutorFactory;
                         })
                     .As<Task<IEndpointExecutorFactory>>()

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/endpoints/IEndpointExecutorRetrySignal.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/endpoints/IEndpointExecutorRetrySignal.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
+{
+    using System;
+
+    // Decouples a transport connectivity-recovery event from endpoint FSM retries.
+    public interface IEndpointExecutorRetrySignal
+    {
+        event EventHandler RetryRequested;
+    }
+
+    public sealed class EndpointExecutorRetrySignal : IEndpointExecutorRetrySignal
+    {
+        public event EventHandler RetryRequested;
+
+        public void RequestRetry() => this.RetryRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
         readonly CancellationTokenSource cts = new CancellationTokenSource();
         readonly ICheckpointerFactory checkpointerFactory;
         readonly EndpointExecutorConfig config;
+        readonly IEndpointExecutorRetrySignal retrySignal;
         AtomicReference<ImmutableDictionary<uint, EndpointExecutorFsm>> prioritiesToFsms;
         EndpointExecutorFsm lastUsedFsm;
 
@@ -38,15 +39,21 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             ICheckpointerFactory checkpointerFactory,
             EndpointExecutorConfig config,
             AsyncEndpointExecutorOptions options,
-            IMessageStore messageStore)
+            IMessageStore messageStore,
+            IEndpointExecutorRetrySignal retrySignal = null)
         {
             this.Endpoint = Preconditions.CheckNotNull(endpoint);
             this.checkpointerFactory = Preconditions.CheckNotNull(checkpointerFactory);
             this.config = Preconditions.CheckNotNull(config);
             this.options = Preconditions.CheckNotNull(options);
             this.messageStore = messageStore;
+            this.retrySignal = retrySignal;
             this.sendMessageTask = Task.Run(this.SendMessagesPump);
             this.prioritiesToFsms = new AtomicReference<ImmutableDictionary<uint, EndpointExecutorFsm>>(ImmutableDictionary<uint, EndpointExecutorFsm>.Empty);
+            if (this.retrySignal != null)
+            {
+                this.retrySignal.RetryRequested += this.HandleRetryRequested;
+            }
         }
 
         public Endpoint Endpoint { get; }
@@ -90,6 +97,11 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             {
                 if (!this.closed.GetAndSet(true))
                 {
+                    if (this.retrySignal != null)
+                    {
+                        this.retrySignal.RetryRequested -= this.HandleRetryRequested;
+                    }
+
                     this.cts.Cancel();
                     // Require to close all FSMs to complete currently executing command if any in order to unblock sendMessageTask.
                     ImmutableDictionary<uint, EndpointExecutorFsm> snapshot = this.prioritiesToFsms;
@@ -299,10 +311,37 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             await command.Completion;
         }
 
+        void HandleRetryRequested(object sender, EventArgs eventArgs)
+        {
+            if (!this.closed)
+            {
+                _ = Task.Run(this.RetryFailingEndpointsAsync);
+            }
+        }
+
+        async Task RetryFailingEndpointsAsync()
+        {
+            try
+            {
+                ImmutableDictionary<uint, EndpointExecutorFsm> snapshot = this.prioritiesToFsms;
+                await Task.WhenAll(snapshot.Values.Select(fsm => fsm.RetryNowAsync()));
+                Events.RetryRequested(this);
+            }
+            catch (Exception ex)
+            {
+                Events.RetryRequestFailure(this, ex);
+            }
+        }
+
         void Dispose(bool disposing)
         {
             if (disposing)
             {
+                if (this.retrySignal != null)
+                {
+                    this.retrySignal.RetryRequested -= this.HandleRetryRequested;
+                }
+
                 this.cts.Dispose();
                 ImmutableDictionary<uint, EndpointExecutorFsm> snapshot = this.prioritiesToFsms;
                 this.prioritiesToFsms.CompareAndSet(snapshot, ImmutableDictionary<uint, EndpointExecutorFsm>.Empty);
@@ -390,7 +429,9 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                 Close,
                 CloseSuccess,
                 CloseFailure,
-                ErrorInPopulatePump
+                ErrorInPopulatePump,
+                RetryRequested,
+                RetryRequestFailure
             }
 
             public static void AddMessageSuccess(StoringAsyncEndpointExecutor executor, long offset, uint priority, uint timeToLiveSecs)
@@ -482,6 +523,16 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             public static void ErrorInPopulatePump(Exception ex)
             {
                 Log.LogWarning((int)EventIds.ErrorInPopulatePump, ex, "Error in populate messages pump");
+            }
+
+            public static void RetryRequested(StoringAsyncEndpointExecutor executor)
+            {
+                Log.LogDebug((int)EventIds.RetryRequested, "[RetryRequested] Retried failing endpoint FSMs immediately for EndpointId: {0}.", executor.Endpoint.Id);
+            }
+
+            public static void RetryRequestFailure(StoringAsyncEndpointExecutor executor, Exception ex)
+            {
+                Log.LogWarning((int)EventIds.RetryRequestFailure, ex, "[RetryRequestFailure] Failed to retry endpoint FSMs for EndpointId: {0}.", executor.Endpoint.Id);
             }
         }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutorFactory.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutorFactory.cs
@@ -11,12 +11,18 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
         readonly EndpointExecutorConfig config;
         readonly AsyncEndpointExecutorOptions options;
         readonly IMessageStore messageStore;
+        readonly IEndpointExecutorRetrySignal retrySignal;
 
-        public StoringAsyncEndpointExecutorFactory(EndpointExecutorConfig config, AsyncEndpointExecutorOptions options, IMessageStore messageStore)
+        public StoringAsyncEndpointExecutorFactory(
+            EndpointExecutorConfig config,
+            AsyncEndpointExecutorOptions options,
+            IMessageStore messageStore,
+            IEndpointExecutorRetrySignal retrySignal = null)
         {
             this.config = Preconditions.CheckNotNull(config, nameof(config));
             this.options = Preconditions.CheckNotNull(options, nameof(options));
             this.messageStore = Preconditions.CheckNotNull(messageStore, nameof(messageStore));
+            this.retrySignal = retrySignal;
         }
 
         public Task<IEndpointExecutor> CreateAsync(Endpoint endpoint, IList<uint> priorities) => this.CreateAsync(endpoint, priorities, new NullCheckpointerFactory(), this.config);
@@ -29,7 +35,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             Preconditions.CheckNotNull(checkpointerFactory, nameof(checkpointerFactory));
             Preconditions.CheckNotNull(endpointExecutorConfig, nameof(endpointExecutorConfig));
 
-            var endpointExecutor = new StoringAsyncEndpointExecutor(endpoint, checkpointerFactory, endpointExecutorConfig, this.options, this.messageStore);
+            var endpointExecutor = new StoringAsyncEndpointExecutor(endpoint, checkpointerFactory, endpointExecutorConfig, this.options, this.messageStore, this.retrySignal);
             await endpointExecutor.UpdatePriorities(priorities, Option.None<Endpoint>());
             return endpointExecutor;
         }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
@@ -134,6 +134,20 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
             }
         }
 
+        public async Task RetryNowAsync()
+        {
+            using (await this.sync.LockAsync())
+            {
+                if (this.state == State.Failing)
+                {
+                    this.retryTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                    Routing.UserMetricLogger.LogRetryOperation(1, this.Endpoint.IotHubName, this.Endpoint.Name, this.Endpoint.Type);
+                    Events.RetryNow(this);
+                    await RunInternalAsync(this, Commands.Retry);
+                }
+            }
+        }
+
         public Task CloseAsync() => this.RunAsync(Commands.Close);
 
         public void Dispose() => this.Dispose(true);
@@ -545,9 +559,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
         {
             try
             {
-                Routing.UserMetricLogger.LogRetryOperation(1, this.Endpoint.IotHubName, this.Endpoint.Name, this.Endpoint.Type);
-                this.retryTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-                await this.RunAsync(Commands.Retry);
+                await this.RetryNowAsync();
             }
             catch (Exception ex)
             {
@@ -589,7 +601,8 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
                 UpdateEndpoint,
                 UpdateEndpointSuccess,
                 UpdateEndpointFailure,
-                CheckRetryInnerException
+                CheckRetryInnerException,
+                RetryNow
             }
 
             public static void StateEnter(EndpointExecutorFsm fsm)
@@ -756,6 +769,11 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
             public static void RetryFailed(EndpointExecutorFsm fsm, Exception exception)
             {
                 Log.LogError((int)EventIds.RetryFailed, exception, "[RetryFailed] Failed to retry. {0}", GetContextString(fsm));
+            }
+
+            public static void RetryNow(EndpointExecutorFsm fsm)
+            {
+                Log.LogDebug((int)EventIds.RetryNow, "[RetryNow] Retrying immediately after connectivity recovery. {0}", GetContextString(fsm));
             }
 
             public static void Dead(EndpointExecutorFsm fsm, ICollection<IMessage> messages)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ConnectivityAwareClientTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ConnectivityAwareClientTest.cs
@@ -353,6 +353,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             public event EventHandler DeviceDisconnected;
 
+            public event EventHandler ConnectivityRecovered
+            {
+                add { }
+                remove { }
+            }
+
             public Task CallSucceeded() => Task.CompletedTask;
 
             public Task CallTimedOut() => Task.CompletedTask;

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DebouncedSdkBridgeTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DebouncedSdkBridgeTest.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class DebouncedSdkBridgeTest
+    {
+        [Fact]
+        public async Task FlapSettlingConnectedProducesOneFastTransition()
+        {
+            var manager = CreateConnectivityManager();
+            var underlying = CreateUnderlyingClient(out ConnectionStatusChangesHandler sdkHandler);
+            using var client = new ConnectivityAwareClient(
+                underlying.Object,
+                manager.Object,
+                Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"));
+
+            var connected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var disconnected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+            client.SetConnectionStatusChangedHandler((status, reason) =>
+            {
+                if (status == ConnectionStatus.Connected)
+                {
+                    connected.TrySetResult(DateTime.UtcNow);
+                }
+                else
+                {
+                    disconnected.TrySetResult(DateTime.UtcNow);
+                }
+            });
+
+            await client.OpenAsync();
+
+            // Establish a disconnected baseline so the final Connected edge is observable.
+            sdkHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.No_Network);
+            await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            manager.Invocations.Clear();
+            connected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+            disconnected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            for (int i = 0; i < 10; i++)
+            {
+                sdkHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.No_Network);
+                sdkHandler(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+                await Task.Delay(50);
+            }
+
+            DateTime finalEdge = DateTime.UtcNow;
+            sdkHandler(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+            DateTime notification = await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            TimeSpan elapsed = notification - finalEdge;
+
+            Assert.InRange(elapsed, TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(4));
+            Assert.False(disconnected.Task.IsCompleted);
+            manager.Verify(m => m.CallSucceeded(), Times.Once);
+            manager.Verify(m => m.CallTimedOut(), Times.Never);
+        }
+
+        [Fact]
+        public async Task SustainedDisconnectProducesOneFastTransition()
+        {
+            var manager = CreateConnectivityManager();
+            var underlying = CreateUnderlyingClient(out ConnectionStatusChangesHandler sdkHandler);
+            using var client = new ConnectivityAwareClient(
+                underlying.Object,
+                manager.Object,
+                Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"));
+
+            var disconnected = new TaskCompletionSource<DateTime>(TaskCreationOptions.RunContinuationsAsynchronously);
+            client.SetConnectionStatusChangedHandler((status, reason) =>
+            {
+                if (status != ConnectionStatus.Connected)
+                {
+                    disconnected.TrySetResult(DateTime.UtcNow);
+                }
+            });
+
+            await client.OpenAsync();
+            manager.Invocations.Clear();
+
+            DateTime edge = DateTime.UtcNow;
+            sdkHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.No_Network);
+            DateTime notification = await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            TimeSpan elapsed = notification - edge;
+
+            Assert.InRange(elapsed, TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(4));
+            manager.Verify(m => m.CallTimedOut(), Times.Once);
+            manager.Verify(m => m.CallSucceeded(), Times.Never);
+        }
+
+        [Fact]
+        public async Task CloseCancelsPendingTransition()
+        {
+            var manager = CreateConnectivityManager();
+            var underlying = CreateUnderlyingClient(out ConnectionStatusChangesHandler sdkHandler);
+            using var client = new ConnectivityAwareClient(
+                underlying.Object,
+                manager.Object,
+                Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"));
+
+            int disconnected = 0;
+            client.SetConnectionStatusChangedHandler((status, reason) =>
+            {
+                if (status != ConnectionStatus.Connected)
+                {
+                    Interlocked.Increment(ref disconnected);
+                }
+            });
+
+            await client.OpenAsync();
+            manager.Invocations.Clear();
+
+            sdkHandler(ConnectionStatus.Disconnected, ConnectionStatusChangeReason.No_Network);
+            await client.CloseAsync();
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            Assert.Equal(0, disconnected);
+            manager.Verify(m => m.CallTimedOut(), Times.Never);
+        }
+
+        static Mock<IDeviceConnectivityManager> CreateConnectivityManager()
+        {
+            var manager = new Mock<IDeviceConnectivityManager>();
+            manager.Setup(m => m.CallSucceeded()).Returns(Task.CompletedTask);
+            manager.Setup(m => m.CallTimedOut()).Returns(Task.CompletedTask);
+            return manager;
+        }
+
+        static Mock<IClient> CreateUnderlyingClient(out ConnectionStatusChangesHandler sdkHandler)
+        {
+            ConnectionStatusChangesHandler capturedHandler = null;
+            var underlying = new Mock<IClient>();
+            underlying.Setup(c => c.SetConnectionStatusChangedHandler(It.IsAny<ConnectionStatusChangesHandler>()))
+                .Callback<ConnectionStatusChangesHandler>(handler => capturedHandler = handler);
+            underlying.Setup(c => c.OpenAsync()).Returns(Task.CompletedTask);
+            underlying.Setup(c => c.CloseAsync()).Returns(Task.CompletedTask);
+            sdkHandler = (status, reason) => capturedHandler(status, reason);
+            return underlying;
+        }
+    }
+}

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceConnectivityManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceConnectivityManagerTest.cs
@@ -18,6 +18,29 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     public class DeviceConnectivityManagerTest
     {
         [Fact]
+        public async Task ConnectivityRecoveredFiresForTryingToConnectedTransitionTest()
+        {
+            var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
+            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromHours(1), TimeSpan.FromHours(1), edgeHubIdentity);
+            int connectivityRecovered = 0;
+            int deviceConnected = 0;
+            deviceConnectivityManager.ConnectivityRecovered += (_, __) => Interlocked.Increment(ref connectivityRecovered);
+            deviceConnectivityManager.DeviceConnected += (_, __) => Interlocked.Increment(ref deviceConnected);
+
+            // Initial startup transitions Disconnected -> Connected.
+            await deviceConnectivityManager.CallSucceeded();
+            Assert.Equal(1, connectivityRecovered);
+            Assert.Equal(1, deviceConnected);
+
+            // A short outage only reaches Trying, not Disconnected. Recovery must still
+            // wake endpoint retries, without changing the existing DeviceConnected semantics.
+            await deviceConnectivityManager.CallTimedOut();
+            await deviceConnectivityManager.CallSucceeded();
+            Assert.Equal(2, connectivityRecovered);
+            Assert.Equal(1, deviceConnected);
+        }
+
+        [Fact]
         public async Task NoEventsTest()
         {
             // Arrange / act

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -1452,6 +1452,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             public event EventHandler DeviceDisconnected;
 
+            public event EventHandler ConnectivityRecovered
+            {
+                add { }
+                remove { }
+            }
+
             public Task CallSucceeded() => Task.CompletedTask;
 
             public Task CallTimedOut() => Task.CompletedTask;

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/StoringAsyncEndpointExecutorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/StoringAsyncEndpointExecutorTest.cs
@@ -21,6 +21,59 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints
     public class StoringAsyncEndpointExecutorTest
     {
         [Fact]
+        public async Task ConnectivityRecoveryInterruptsRetryBackoffTest()
+        {
+            const string EndpointId = "endpoint1";
+            const uint Priority = 0;
+            var endpoint = new TestEndpoint(EndpointId) { CanProcess = false };
+            var retrySignal = new EndpointExecutorRetrySignal();
+            var config = new EndpointExecutorConfig(
+                TimeSpan.FromSeconds(30),
+                new FixedInterval(int.MaxValue, TimeSpan.FromMinutes(1)),
+                TimeSpan.FromSeconds(30));
+            var options = new AsyncEndpointExecutorOptions(10, TimeSpan.FromSeconds(10));
+            var messageStore = new TestMessageStore();
+            var executor = new StoringAsyncEndpointExecutor(
+                endpoint,
+                new NullCheckpointerFactory(),
+                config,
+                options,
+                messageStore,
+                retrySignal);
+            await executor.UpdatePriorities(new List<uint> { Priority }, Option.None<Endpoint>());
+
+            await executor.Invoke(GetNewMessages(1, 0).First(), Priority, 3600);
+            for (int i = 0; i < 50 && executor.Status.RetryAttempts == 0; i++)
+            {
+                await Task.Delay(100);
+            }
+
+            Assert.Equal(0, endpoint.N);
+            Assert.True(executor.Status.RetryAttempts > 0);
+            Assert.Equal(TimeSpan.FromMinutes(1), executor.Status.RetryPeriod);
+
+            endpoint.CanProcess = true;
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            retrySignal.RequestRetry();
+            while (sw.Elapsed < TimeSpan.FromSeconds(5) && endpoint.N == 0)
+            {
+                await Task.Delay(50);
+            }
+
+            Assert.Equal(1, endpoint.N);
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5), $"Reconnect-triggered retry took {sw.Elapsed}.");
+
+            // Repeated connected signals are harmless once the FSM is no longer failing.
+            retrySignal.RequestRetry();
+            await Task.Delay(100);
+            Assert.Equal(1, endpoint.N);
+            await executor.CloseAsync();
+
+            // The executor unsubscribes when closed.
+            retrySignal.RequestRetry();
+        }
+
+        [Fact]
         public async Task InvokeTest()
         {
             // Arrange


### PR DESCRIPTION
## Summary

- Bridge stable Device SDK connection-status changes into edgeHub's connectivity manager after a 2-second debounce.
- Surface recovery from both `Trying -> Connected` and `Disconnected -> Connected` without changing the existing `DeviceConnected` event semantics.
- Interrupt a parked endpoint FSM retry timer when connectivity recovers so store-and-forward resumes immediately instead of waiting out up to 60 seconds of exponential backoff per hop.
- Guard timer-versus-signal races under the FSM lock, queue retry work off the connectivity callback thread, and unsubscribe on executor shutdown.

## Why

In the nested E2E failure, a short upstream AMQP disruption becomes a multi-minute store-and-forward delay. Detection is one part of the delay, but the endpoint executor adds another sawtooth: if connectivity returns while the FSM is in `Failing`, the queued message waits for the already-armed retry timer.

A local reproduction against the real `StoringAsyncEndpointExecutor` and `EndpointExecutorFsm` measured:

| Outage | Drain after recovery |
|---|---:|
| 0s | 3.4s |
| 15s | 13.9s |
| 60s | 1.0s |
| 120s | 53.3s |

The variance depends on where recovery lands in the 1-to-60-second exponential-backoff cycle. The new recovery signal interrupts that timer. A focused test parks the FSM in a 60-second retry interval and verifies delivery in under 5 seconds after recovery; the real 15-second outage shape also passes the under-5-second assertion.

## Validation

- `Microsoft.Azure.Devices.Routing.Core.Test`: 1,159 passed
- `Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test`: 183 passed, 7 skipped
- `ConnectionManagerTest`: 25 passed
- edgeHub Service build: 0 warnings, 0 errors
- Nested E2E: pending CI image build

## Draft scope

The SDK bridge is enabled for the E2E experiment. Make it configurable before merge.
