### PR TITLE
test: persist nested-e2e edgeHub store across container recreate (diagnostic)

### DIFF
--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -152,8 +152,52 @@ stages:
     - LockAgents
     - RunNestedTests
   jobs:
+  # TEMP (investigation, not for merge): capture support bundles from ALL levels (L3/L4/L5)
+  # after the test stage, so the L4/L5 edgeHub/relayer logs are available to debug
+  # RouteMessageL3LeafToL4Module. Runs before Clean_images so containers/logs still exist.
+  - job: Collect_Nested_Bundles
+    displayName: Collect nested support bundles
+    condition: always()
+    strategy:
+      matrix:
+        L3:
+          level: 3
+        L4:
+          level: 4
+        L5:
+          level: 5
+    pool:
+      name: $(pool.name)
+      demands:
+        - agent-group -equals $(agent.group)
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - status -equals locked_$(Build.BuildId)_L$(level)
+    steps:
+      - bash: |
+          set +e
+          out="$(Build.ArtifactStagingDirectory)/nested-bundle-L$(level)"
+          mkdir -p "$out"
+          echo "Collecting support bundle on L$(level) ($(hostname))"
+          sudo iotedge support-bundle --output "$out/support_bundle_L$(level).zip" || echo "support-bundle failed on L$(level)"
+          # Also grab raw module logs as a fallback in case support-bundle errors
+          for m in edgeHub edgeAgent relayer1; do
+            sudo docker logs "$m" > "$out/$m-L$(level).log" 2>&1 || true
+          done
+          ls -la "$out" || true
+        displayName: 'Generate support bundle (L$(level))'
+        condition: always()
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish nested bundle (L$(level))'
+        condition: always()
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)/nested-bundle-L$(level)'
+          ArtifactName: 'nested-support-bundles'
+
   - job: Clean_images
     displayName: Clean up Docker images
+    dependsOn: Collect_Nested_Bundles
+    condition: always()
     strategy:
       matrix:
         L3:

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -67,6 +67,10 @@ steps:
         # Below tests were disabled and marked for re-enable when a blocking item was resolved.
         # When it was resolved the tests were never enabled. We need to re-enable these.
         $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
+        # TEMP (investigation, not for merge): narrow to the smallest set that reproduces
+        # RouteMessageL3LeafToL4Module. Metrics + IoTEdgeCheck must run before RouteMessage
+        # to provoke the AMQP upstream blip (derived from PR #7521 bisection, run 20260701.8).
+        $filter += '&(FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.Module|FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.Metrics|FullyQualifiedName~IoTEdgeCheck|FullyQualifiedName~RouteMessageL3LeafToL4Module)'
       }
       elseif ($test_type -eq 'nestededge_isa95')
       {

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -67,10 +67,6 @@ steps:
         # Below tests were disabled and marked for re-enable when a blocking item was resolved.
         # When it was resolved the tests were never enabled. We need to re-enable these.
         $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
-        # TEMP (investigation, not for merge): narrow to the smallest set that reproduces
-        # RouteMessageL3LeafToL4Module. Metrics + IoTEdgeCheck must run before RouteMessage
-        # to provoke the AMQP upstream blip (derived from PR #7521 bisection, run 20260701.8).
-        $filter += '&(FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.Module|FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.Metrics|FullyQualifiedName~IoTEdgeCheck|FullyQualifiedName~RouteMessageL3LeafToL4Module)'
       }
       elseif ($test_type -eq 'nestededge_isa95')
       {

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
@@ -27,9 +27,12 @@
             "type": "docker",
             "settings": {
               "image": "$upstream:443/microsoft/azureiotedge-hub:<Build.BuildNumber>-linux-<Architecture>",
-              "createOptions": "{\"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\",\"compress\":\"true\"}}, \"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
+              "createOptions": "{\"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\",\"compress\":\"true\"}}, \"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}, \"Binds\": [\"/etc/iotedge/storage/:/iotedge/storage/\"]}}"
             },
             "env": {
+              "StorageFolder": {
+                "value": "/iotedge/storage"
+              },
               "DeviceScopeCacheRefreshDelaySecs": {
                 "value": 0
               },

--- a/e2e_deployment_files/nestededge_middleLayer_e2e_amqp.json
+++ b/e2e_deployment_files/nestededge_middleLayer_e2e_amqp.json
@@ -27,9 +27,12 @@
                         "type": "docker",
                         "settings": {
                             "image": "$upstream:443/microsoft/azureiotedge-hub:<Build.BuildNumber>-linux-<Architecture>",
-                            "createOptions": "{\"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\",\"compress\":\"true\"}}, \"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
+                            "createOptions": "{\"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\",\"compress\":\"true\"}}, \"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}, \"Binds\": [\"/etc/iotedge/storage/:/iotedge/storage/\"]}}"
                         },
                         "env": {
+                            "StorageFolder": {
+                                "value": "/iotedge/storage"
+                            },
                             "experimentalFeatures__enabled": {
                                 "value": "true"
                             },

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -97,7 +97,19 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
         public async Task<Device> CreateDeviceIdentityAsync(Device device, CancellationToken token)
         {
-            return await this.RegistryManager.AddDeviceAsync(device, token);
+            try
+            {
+                return await this.RegistryManager.AddDeviceAsync(device, token);
+            }
+            catch (DeviceAlreadyExistsException)
+            {
+                // A prior test run can leave an orphaned identity behind (for example when the
+                // job is killed during artifact upload before cleanup runs). Remove the stale
+                // identity and recreate so the repro run isn't blocked by leftover state.
+                Log.Warning($"Device identity '{device.Id}' already exists; deleting orphaned identity and recreating.");
+                await this.RegistryManager.RemoveDeviceAsync(device.Id, token);
+                return await this.RegistryManager.AddDeviceAsync(device, token);
+            }
         }
 
         public async Task<Device> CreateEdgeDeviceIdentityAsync(string deviceId, Option<string> parentDeviceId, AuthenticationType authType, X509Thumbprint x509Thumbprint, CancellationToken token)


### PR DESCRIPTION
## Summary

The nested-E2E edgeHub stores store-and-forward messages at the default `/tmp/edgeHub`, which lives in the container's ephemeral writable layer. When the AMQP-group redeploy recreates the L4 edgeHub container mid-test, any queued or undelivered message is lost with the wiped store.

This mounts a host directory (`/etc/iotedge/storage`) into edgeHub and points its `StorageFolder` at it, so the message store survives an edgeHub container recreate. edgeHub's entrypoint (`hubStart.sh`) creates and chowns `$StorageFolder/edgeHub` to the edgehub uid at startup, so no host-side preparation is needed.

Applies to both middle-layer AMQP deployments (`nestededge_middleLayerBaseDeployment_amqp.json` and `nestededge_middleLayer_e2e_amqp.json`).

## Why (diagnostic)

Investigating why `RouteMessageL3LeafToL4Module` fails, the message the test waits on is stranded when the L4 edgeHub container is delete+recreated by the mid-test deployment reconcile. Because the store is ephemeral, the queued message is destroyed with the old container rather than being retried on reconnect.

This change is a **diagnostic to separate two hypotheses**:

- If RouteMessage **passes** with a persistent store, the failing message was purely lost to the container-recreate store wipe (a test-rig gap).
- If it **still stalls**, the message is orphaned within a surviving store, which isolates the defect to edgeHub's store-and-forward re-pump on reconnect.

## Draft scope

Draft, not for merge as-is. This is a targeted experiment to inform the durable edgeHub store-and-forward fix. If persistent storage is the right long-term posture for the nested-E2E rig (arguably it is, since store-and-forward across a restart is a real customer scenario), the mount path and provisioning should be reviewed for the CI agents.
