### PR TITLE
Throttle repeated cloud proxy rebuilds

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ClientTokenCloudConnection.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ClientTokenCloudConnection.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
@@ -23,7 +24,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         readonly AsyncLock identityUpdateLock = new AsyncLock();
 
         bool callbacksEnabled = true;
-        Option<TaskCompletionSource<string>> tokenGetter;
+        TaskCompletionSource<string> tokenGetter;
+        int tokenUpdatesCanceled;
         Option<ICloudProxy> cloudProxy;
 
         ClientTokenCloudConnection(
@@ -123,20 +125,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                 // If the Identity has a token, and we have a tokenGetter, that means
                                 // the connection is waiting for a new token. So give it the token and
                                 // complete the tokenGetter
-                                if (this.tokenGetter.HasValue)
+                                if (Volatile.Read(ref this.tokenGetter) != null)
                                 {
-                                    if (TokenHelper.IsTokenExpired(this.Identity.IotHubHostname, newTokenCredentials.Token))
-                                    {
-                                        throw new InvalidOperationException($"Token for client {this.Identity.Id} is expired");
-                                    }
-
-                                    this.tokenGetter.ForEach(
-                                        tg =>
-                                        {
-                                            // First reset the token getter and then set the result.
-                                            this.tokenGetter = Option.None<TaskCompletionSource<string>>();
-                                            tg.SetResult(newTokenCredentials.Token);
-                                        });
+                                    this.CompleteTokenGetter(newTokenCredentials);
                                     return cp;
                                 }
                                 else
@@ -148,8 +139,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                     return newCloudProxy;
                                 }
                             })
-                        // No existing cloud proxy, so just create a new one.
-                        .GetOrElse(() => this.CreateNewCloudProxyAsync(tokenProvider));
+                        .GetOrElse(
+                            async () =>
+                            {
+                                this.CompleteTokenGetter(newTokenCredentials);
+                                return await this.CreateNewCloudProxyAsync(tokenProvider);
+                            });
 
                     // Set Identity only after successfully opening cloud proxy
                     // That way, if a we have one existing connection for a deviceA,
@@ -172,6 +167,26 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         }
 
         protected override Option<ICloudProxy> GetCloudProxy() => this.cloudProxy;
+
+        public bool HasPendingTokenUpdate => Volatile.Read(ref this.tokenGetter) != null;
+
+        public void CancelTokenUpdate()
+        {
+            Volatile.Write(ref this.tokenUpdatesCanceled, 1);
+            Interlocked.Exchange(ref this.tokenGetter, null)?.TrySetCanceled();
+        }
+
+        void CompleteTokenGetter(ITokenCredentials newTokenCredentials)
+        {
+            TaskCompletionSource<string> currentTokenGetter = Volatile.Read(ref this.tokenGetter);
+            if (currentTokenGetter != null
+                && TokenHelper.IsTokenExpired(this.Identity.IotHubHostname, newTokenCredentials.Token))
+            {
+                throw new InvalidOperationException($"Token for client {this.Identity.Id} is expired");
+            }
+
+            Interlocked.Exchange(ref this.tokenGetter, null)?.TrySetResult(newTokenCredentials.Token);
+        }
 
         // Checks if the token expires too soon
         static bool IsTokenUsable(string hostname, string token)
@@ -222,17 +237,35 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 }
 
                 bool newTokenGetterCreated = false;
+                if (Volatile.Read(ref this.tokenUpdatesCanceled) != 0)
+                {
+                    throw new OperationCanceledException(
+                        $"Token updates for client {this.Identity.Id} have been canceled.");
+                }
+
                 // No need to lock here as the lock is being held by the refresher.
-                TaskCompletionSource<string> tcs = this.tokenGetter
-                    .GetOrElse(
-                        () =>
-                        {
-                            Events.SafeCreateNewToken(this.Identity.Id);
-                            var taskCompletionSource = new TaskCompletionSource<string>();
-                            this.tokenGetter = Option.Some(taskCompletionSource);
-                            newTokenGetterCreated = true;
-                            return taskCompletionSource;
-                        });
+                TaskCompletionSource<string> tcs = Volatile.Read(ref this.tokenGetter);
+                if (tcs == null)
+                {
+                    Events.SafeCreateNewToken(this.Identity.Id);
+                    var taskCompletionSource = new TaskCompletionSource<string>();
+                    tcs = Interlocked.CompareExchange(
+                        ref this.tokenGetter,
+                        taskCompletionSource,
+                        null);
+                    if (tcs == null)
+                    {
+                        tcs = taskCompletionSource;
+                        newTokenGetterCreated = true;
+                    }
+                }
+
+                if (Volatile.Read(ref this.tokenUpdatesCanceled) != 0)
+                {
+                    this.CancelTokenUpdate();
+                    throw new OperationCanceledException(
+                        $"Token updates for client {this.Identity.Id} have been canceled.");
+                }
 
                 // If a new tokenGetter was created, then invoke the connection status changed handler
                 if (newTokenGetterCreated)
@@ -241,6 +274,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                     if (retrying)
                     {
                         await Task.Delay(TokenRetryWaitTime);
+                    }
+
+                    if (Volatile.Read(ref this.tokenUpdatesCanceled) != 0)
+                    {
+                        this.CancelTokenUpdate();
+                        throw new OperationCanceledException(
+                            $"Token updates for client {this.Identity.Id} have been canceled.");
                     }
 
                     this.ConnectionStatusChangedHandler(this.Identity.Id, CloudConnectionStatus.TokenNearExpiry);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ClientTokenCloudConnection.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ClientTokenCloudConnection.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         static readonly TimeSpan TokenRetryWaitTime = TimeSpan.FromSeconds(20);
 
         readonly AsyncLock identityUpdateLock = new AsyncLock();
+        readonly Func<Task> tokenRetryDelay;
 
         bool callbacksEnabled = true;
         TaskCompletionSource<string> tokenGetter;
@@ -40,7 +41,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             TimeSpan operationTimeout,
             TimeSpan cloudConnectionHangingTimeout,
             string productInfo,
-            Option<string> modelId)
+            Option<string> modelId,
+            Func<Task> tokenRetryDelay)
             : base(
                 identity,
                 connectionStatusChangedHandler,
@@ -55,11 +57,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 productInfo,
                 modelId)
         {
+            this.tokenRetryDelay = tokenRetryDelay;
         }
 
         protected override bool CallbacksEnabled => this.callbacksEnabled;
 
-        public static async Task<ClientTokenCloudConnection> Create(
+        public static Task<ClientTokenCloudConnection> Create(
             ITokenCredentials tokenCredentials,
             Action<string, CloudConnectionStatus> connectionStatusChangedHandler,
             ITransportSettings[] transportSettings,
@@ -72,8 +75,38 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             TimeSpan cloudConnectionHangingTimeout,
             string productInfo,
             Option<string> modelId)
+            => Create(
+                tokenCredentials,
+                connectionStatusChangedHandler,
+                transportSettings,
+                messageConverterProvider,
+                clientProvider,
+                cloudListener,
+                idleTimeout,
+                closeOnIdleTimeout,
+                operationTimeout,
+                cloudConnectionHangingTimeout,
+                productInfo,
+                modelId,
+                () => Task.Delay(TokenRetryWaitTime));
+
+        internal static async Task<ClientTokenCloudConnection> Create(
+            ITokenCredentials tokenCredentials,
+            Action<string, CloudConnectionStatus> connectionStatusChangedHandler,
+            ITransportSettings[] transportSettings,
+            IMessageConverterProvider messageConverterProvider,
+            IClientProvider clientProvider,
+            ICloudListener cloudListener,
+            TimeSpan idleTimeout,
+            bool closeOnIdleTimeout,
+            TimeSpan operationTimeout,
+            TimeSpan cloudConnectionHangingTimeout,
+            string productInfo,
+            Option<string> modelId,
+            Func<Task> tokenRetryDelay)
         {
             Preconditions.CheckNotNull(tokenCredentials, nameof(tokenCredentials));
+            Preconditions.CheckNotNull(tokenRetryDelay, nameof(tokenRetryDelay));
             var cloudConnection = new ClientTokenCloudConnection(
                 tokenCredentials.Identity,
                 connectionStatusChangedHandler,
@@ -86,7 +119,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 operationTimeout,
                 cloudConnectionHangingTimeout,
                 productInfo,
-                modelId);
+                modelId,
+                tokenRetryDelay);
             ITokenProvider tokenProvider = new ClientTokenBasedTokenProvider(tokenCredentials, cloudConnection);
             ICloudProxy cloudProxy = await cloudConnection.CreateNewCloudProxyAsync(tokenProvider);
             cloudConnection.cloudProxy = Option.Some(cloudProxy);
@@ -94,17 +128,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         }
 
         /// <summary>
-        /// This method does the following -
-        ///     1. Updates the Identity to be used for the cloud connection
-        ///     2. Updates the cloud proxy -
-        ///         i. If there is an existing device client and
-        ///             a. If is waiting for an updated token, and the Identity has a token,
-        ///                then it uses that to give it to the waiting client authentication method.
-        ///             b. If not, then it creates a new cloud proxy (and device client) and closes the existing one
-        ///         ii. Else, if there is no cloud proxy, then opens a device client and creates a cloud proxy.
+        /// Applies new token credentials to the cloud connection.
         /// </summary>
+        /// <remarks>
+        /// A pending token request reuses the existing proxy. Otherwise, a replacement proxy opens
+        /// before the existing proxy closes so invalid credentials do not disrupt an active connection.
+        /// </remarks>
         /// <param name="newTokenCredentials">New token credentials.</param>
-        /// <returns>task of ICloudProxy interface.</returns>
+        /// <returns>The active cloud proxy.</returns>
         public async Task<ICloudProxy> UpdateTokenAsync(ITokenCredentials newTokenCredentials)
         {
             Preconditions.CheckNotNull(newTokenCredentials, nameof(newTokenCredentials));
@@ -203,12 +234,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         }
 
         /// <summary>
-        /// If the existing Identity has a usable token, then use it.
-        /// Else, generate a notification of token being near expiry and return a task that
-        /// can be completed later.
-        /// Keep retrying till we get a usable token.
-        /// Note - Don't use this.Identity in this method, as it may not have been set yet!
+        /// Returns the supplied token when usable; otherwise, requests replacement tokens until one is usable.
         /// </summary>
+        /// <remarks>
+        /// Token validation uses the supplied value because the connection identity may not yet contain
+        /// the latest credentials.
+        /// </remarks>
+        /// <param name="currentToken">The token to validate first.</param>
+        /// <returns>A usable token.</returns>
+        /// <exception cref="OperationCanceledException">Token updates have been canceled.</exception>
         async Task<string> GetNewToken(string currentToken)
         {
             Events.GetNewToken(this.Identity.Id);
@@ -216,8 +250,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             string token = currentToken;
             while (true)
             {
-                // We have to catch UnauthorizedAccessException, because on IsTokenUsable, we call parse from
-                // Device Client and it throws if the token is expired.
                 if (IsTokenUsable(this.Identity.IotHubHostname, token))
                 {
                     if (retrying)
@@ -231,19 +263,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
                     return token;
                 }
-                else
-                {
-                    Events.TokenNotUsable(this.Identity, token);
-                }
 
-                bool newTokenGetterCreated = false;
-                if (Volatile.Read(ref this.tokenUpdatesCanceled) != 0)
-                {
-                    throw new OperationCanceledException(
-                        $"Token updates for client {this.Identity.Id} have been canceled.");
-                }
+                Events.TokenNotUsable(this.Identity, token);
 
-                // No need to lock here as the lock is being held by the refresher.
+                bool tokenGetterPublished = false;
+                this.ThrowIfTokenUpdatesCanceled(cancelPublishedWaiter: false);
                 TaskCompletionSource<string> tcs = Volatile.Read(ref this.tokenGetter);
                 if (tcs == null)
                 {
@@ -256,40 +280,42 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                     if (tcs == null)
                     {
                         tcs = taskCompletionSource;
-                        newTokenGetterCreated = true;
+                        tokenGetterPublished = true;
                     }
                 }
 
-                if (Volatile.Read(ref this.tokenUpdatesCanceled) != 0)
-                {
-                    this.CancelTokenUpdate();
-                    throw new OperationCanceledException(
-                        $"Token updates for client {this.Identity.Id} have been canceled.");
-                }
+                this.ThrowIfTokenUpdatesCanceled(cancelPublishedWaiter: true);
 
-                // If a new tokenGetter was created, then invoke the connection status changed handler
-                if (newTokenGetterCreated)
+                if (tokenGetterPublished)
                 {
-                    // If retrying, wait for some time.
                     if (retrying)
                     {
-                        await Task.Delay(TokenRetryWaitTime);
+                        await this.tokenRetryDelay();
                     }
 
-                    if (Volatile.Read(ref this.tokenUpdatesCanceled) != 0)
-                    {
-                        this.CancelTokenUpdate();
-                        throw new OperationCanceledException(
-                            $"Token updates for client {this.Identity.Id} have been canceled.");
-                    }
-
+                    this.ThrowIfTokenUpdatesCanceled(cancelPublishedWaiter: true);
                     this.ConnectionStatusChangedHandler(this.Identity.Id, CloudConnectionStatus.TokenNearExpiry);
                 }
 
                 retrying = true;
-                // this.tokenGetter will be reset when this task returns.
                 token = await tcs.Task;
             }
+        }
+
+        void ThrowIfTokenUpdatesCanceled(bool cancelPublishedWaiter)
+        {
+            if (Volatile.Read(ref this.tokenUpdatesCanceled) == 0)
+            {
+                return;
+            }
+
+            if (cancelPublishedWaiter)
+            {
+                Interlocked.Exchange(ref this.tokenGetter, null)?.TrySetCanceled();
+            }
+
+            throw new OperationCanceledException(
+                $"Token updates for client {this.Identity.Id} have been canceled.");
         }
 
         class ClientTokenBasedTokenProvider : ITokenProvider

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     public class ConnectionManager : IConnectionManager
     {
         const int DefaultMaxClients = 101; // 100 Clients + 1 Edgehub
+        static readonly TimeSpan DefaultCloudConnectionRetryInterval = TimeSpan.FromSeconds(5);
         readonly object deviceConnLock = new object();
         readonly AsyncReaderWriterLock connectToCloudLock = new AsyncReaderWriterLock();
         readonly ConcurrentDictionary<string, ConnectedDevice> devices = new ConcurrentDictionary<string, ConnectedDevice>();
@@ -30,6 +31,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         readonly IIdentityProvider identityProvider;
         readonly IDeviceConnectivityManager connectivityManager;
         readonly bool closeCloudConnectionOnDeviceDisconnect;
+        readonly TimeSpan cloudConnectionRetryInterval;
+        readonly ISystemTime systemTime;
 
         public ConnectionManager(
             ICloudConnectionProvider cloudConnectionProvider,
@@ -38,12 +41,37 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             IDeviceConnectivityManager connectivityManager,
             int maxClients = DefaultMaxClients,
             bool closeCloudConnectionOnDeviceDisconnect = true)
+            : this(
+                cloudConnectionProvider,
+                credentialsCache,
+                identityProvider,
+                connectivityManager,
+                maxClients,
+                closeCloudConnectionOnDeviceDisconnect,
+                DefaultCloudConnectionRetryInterval,
+                SystemTime.Instance)
+        {
+        }
+
+        internal ConnectionManager(
+            ICloudConnectionProvider cloudConnectionProvider,
+            ICredentialsCache credentialsCache,
+            IIdentityProvider identityProvider,
+            IDeviceConnectivityManager connectivityManager,
+            int maxClients,
+            bool closeCloudConnectionOnDeviceDisconnect,
+            TimeSpan cloudConnectionRetryInterval,
+            ISystemTime systemTime)
         {
             this.cloudConnectionProvider = Preconditions.CheckNotNull(cloudConnectionProvider, nameof(cloudConnectionProvider));
             this.maxClients = Preconditions.CheckRange(maxClients, 1, nameof(maxClients));
             this.credentialsCache = Preconditions.CheckNotNull(credentialsCache, nameof(credentialsCache));
             this.identityProvider = Preconditions.CheckNotNull(identityProvider, nameof(identityProvider));
             this.connectivityManager = Preconditions.CheckNotNull(connectivityManager, nameof(connectivityManager));
+            this.cloudConnectionRetryInterval = cloudConnectionRetryInterval >= TimeSpan.Zero
+                ? cloudConnectionRetryInterval
+                : throw new ArgumentOutOfRangeException(nameof(cloudConnectionRetryInterval));
+            this.systemTime = Preconditions.CheckNotNull(systemTime, nameof(systemTime));
             this.connectivityManager.DeviceDisconnected += (o, args) => this.HandleDeviceCloudConnectionDisconnected();
             this.closeCloudConnectionOnDeviceDisconnect = closeCloudConnectionOnDeviceDisconnect;
         }
@@ -91,27 +119,28 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public async Task<Option<ICloudProxy>> GetCloudConnection(string id)
         {
-            Try<ICloudProxy> cloudProxyTry = await this.TryGetCloudConnectionInternal(id);
+            Try<ICloudProxy> cloudProxyTry = await this.TryGetCloudConnectionInternal(id, false);
             return cloudProxyTry
                 .Ok()
-                .Map(c => (ICloudProxy)new RetryingCloudProxy(id, () => this.TryGetCloudConnectionInternal(id), c));
+                .Map(c => (ICloudProxy)new RetryingCloudProxy(id, () => this.TryGetCloudConnectionInternal(id, true), c));
         }
 
         public async Task<Try<ICloudProxy>> TryGetCloudConnection(string id)
         {
-            Try<ICloudProxy> cloudProxyTry = await this.TryGetCloudConnectionInternal(id);
+            Try<ICloudProxy> cloudProxyTry = await this.TryGetCloudConnectionInternal(id, false);
             return cloudProxyTry.Success
-                ? Try.Success((ICloudProxy)new RetryingCloudProxy(id, () => this.TryGetCloudConnectionInternal(id), cloudProxyTry.Value))
+                ? Try.Success((ICloudProxy)new RetryingCloudProxy(id, () => this.TryGetCloudConnectionInternal(id, true), cloudProxyTry.Value))
                 : cloudProxyTry;
         }
 
-        async Task<Try<ICloudProxy>> TryGetCloudConnectionInternal(string id)
+        async Task<Try<ICloudProxy>> TryGetCloudConnectionInternal(string id, bool isRetry)
         {
             IIdentity identity = this.identityProvider.Create(Preconditions.CheckNonWhiteSpace(id, nameof(id)));
             ConnectedDevice device = this.GetOrCreateConnectedDevice(identity);
 
             Try<ICloudConnection> cloudConnectionTry = await device.GetOrCreateCloudConnection(
-                c => this.ConnectToCloud(c.Identity, this.CloudConnectionStatusChangedHandler));
+                c => this.ConnectToCloud(c.Identity, this.CloudConnectionStatusChangedHandler),
+                isRetry);
 
             Events.GetCloudConnection(device.Identity, cloudConnectionTry);
             Try<ICloudProxy> cloudProxyTry = GetCloudProxyFromCloudConnection(cloudConnectionTry, device.Identity);
@@ -221,7 +250,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             Events.NewCloudConnection(credentials.Identity, newCloudConnection);
             Try<ICloudProxy> cloudProxyTry = GetCloudProxyFromCloudConnection(newCloudConnection, credentials.Identity);
             return cloudProxyTry.Success
-                ? Try.Success((ICloudProxy)new RetryingCloudProxy(credentials.Identity.Id, () => this.TryGetCloudConnectionInternal(credentials.Identity.Id), cloudProxyTry.Value))
+                ? Try.Success((ICloudProxy)new RetryingCloudProxy(credentials.Identity.Id, () => this.TryGetCloudConnectionInternal(credentials.Identity.Id, true), cloudProxyTry.Value))
                 : cloudProxyTry;
         }
 
@@ -235,11 +264,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             // instance to this.devices and return that.
             ConnectedDevice device = this.GetOrCreateConnectedDevice(credentials.Identity);
 
-            Try<ICloudConnection> cloudConnectionTry = await device.GetOrCreateCloudConnection((c) => this.CreateOrUpdateCloudConnection(c, credentials));
+            Try<ICloudConnection> cloudConnectionTry = await device.GetOrCreateCloudConnection(
+                c => this.CreateOrUpdateCloudConnection(c, credentials),
+                false);
             Events.GetCloudConnection(credentials.Identity, cloudConnectionTry);
             Try<ICloudProxy> cloudProxyTry = GetCloudProxyFromCloudConnection(cloudConnectionTry, credentials.Identity);
             return cloudProxyTry.Success
-                ? Try.Success((ICloudProxy)new RetryingCloudProxy(credentials.Identity.Id, () => this.TryGetCloudConnectionInternal(credentials.Identity.Id), cloudProxyTry.Value))
+                ? Try.Success((ICloudProxy)new RetryingCloudProxy(credentials.Identity.Id, () => this.TryGetCloudConnectionInternal(credentials.Identity.Id, true), cloudProxyTry.Value))
                 : cloudProxyTry;
         }
 
@@ -388,7 +419,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             return this.devices.AddOrUpdate(
                 deviceId,
                 id => this.CreateNewConnectedDevice(identity),
-                (id, cd) => new ConnectedDevice(identity, cd.CloudConnection, cd.DeviceConnection));
+                (id, cd) => new ConnectedDevice(
+                    identity,
+                    cd.CloudConnection,
+                    cd.DeviceConnection,
+                    this.cloudConnectionRetryInterval,
+                    this.systemTime));
         }
 
         ConnectedDevice CreateNewConnectedDevice(IIdentity identity)
@@ -400,7 +436,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     throw new EdgeHubConnectionException($"Edge hub already has maximum allowed clients ({this.maxClients - 1}) connected.");
                 }
 
-                return new ConnectedDevice(identity);
+                return new ConnectedDevice(identity, this.cloudConnectionRetryInterval, this.systemTime);
             }
         }
 
@@ -426,18 +462,34 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             // so using traditional locking mechanism for those.
             readonly object deviceProxyLock = new object();
             readonly AsyncLock cloudConnectionLock = new AsyncLock();
+            readonly TimeSpan cloudConnectionRetryInterval;
+            readonly ISystemTime systemTime;
             Option<Task<Try<ICloudConnection>>> cloudConnectionCreateTask = Option.None<Task<Try<ICloudConnection>>>();
+            Option<DateTime> cloudConnectionCreateCompletedTime = Option.None<DateTime>();
+            bool cloudConnectionCreateWasRetry;
 
-            public ConnectedDevice(IIdentity identity)
-                : this(identity, Option.None<ICloudConnection>(), Option.None<DeviceConnection>())
+            public ConnectedDevice(IIdentity identity, TimeSpan cloudConnectionRetryInterval, ISystemTime systemTime)
+                : this(
+                    identity,
+                    Option.None<ICloudConnection>(),
+                    Option.None<DeviceConnection>(),
+                    cloudConnectionRetryInterval,
+                    systemTime)
             {
             }
 
-            public ConnectedDevice(IIdentity identity, Option<ICloudConnection> cloudProxy, Option<DeviceConnection> deviceConnection)
+            public ConnectedDevice(
+                IIdentity identity,
+                Option<ICloudConnection> cloudProxy,
+                Option<DeviceConnection> deviceConnection,
+                TimeSpan cloudConnectionRetryInterval,
+                ISystemTime systemTime)
             {
                 this.Identity = identity;
                 this.CloudConnection = cloudProxy;
                 this.DeviceConnection = deviceConnection;
+                this.cloudConnectionRetryInterval = cloudConnectionRetryInterval;
+                this.systemTime = systemTime;
             }
 
             public IIdentity Identity { get; }
@@ -465,7 +517,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 // Lock in case multiple connections are created to the cloud for the same device at the same time
                 using (await this.cloudConnectionLock.LockAsync())
                 {
-                    Try<ICloudConnection> newCloudConnection = await cloudConnectionUpdater(this);
+                    Task<Try<ICloudConnection>> updateTask = cloudConnectionUpdater(this);
+                    this.cloudConnectionCreateTask = Option.Some(updateTask);
+                    this.cloudConnectionCreateWasRetry = false;
+                    Try<ICloudConnection> newCloudConnection;
+                    try
+                    {
+                        newCloudConnection = await updateTask;
+                    }
+                    finally
+                    {
+                        this.cloudConnectionCreateCompletedTime = Option.Some(this.systemTime.UtcNow);
+                    }
+
                     if (newCloudConnection.Success)
                     {
                         this.CloudConnection = Option.Some(newCloudConnection.Value);
@@ -476,7 +540,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             }
 
             public async Task<Try<ICloudConnection>> GetOrCreateCloudConnection(
-                Func<ConnectedDevice, Task<Try<ICloudConnection>>> cloudConnectionCreator)
+                Func<ConnectedDevice, Task<Try<ICloudConnection>>> cloudConnectionCreator,
+                bool isRetry)
             {
                 Preconditions.CheckNotNull(cloudConnectionCreator, nameof(cloudConnectionCreator));
 
@@ -496,13 +561,27 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                                                 .GetOrElse(
                                                     async () =>
                                                     {
-                                                        return await this.cloudConnectionCreateTask.Filter(c => !c.IsCompleted)
+                                                        bool retryIntervalElapsed = this.cloudConnectionCreateCompletedTime
+                                                            .Map(t => this.systemTime.UtcNow - t >= this.cloudConnectionRetryInterval)
+                                                            .GetOrElse(true);
+                                                        return await this.cloudConnectionCreateTask.Filter(
+                                                                c => !c.IsCompleted || this.cloudConnectionCreateWasRetry && !retryIntervalElapsed)
                                                             .GetOrElse(
                                                                 async () =>
                                                                 {
                                                                     Task<Try<ICloudConnection>> createTask = cloudConnectionCreator(this);
                                                                     this.cloudConnectionCreateTask = Option.Some(createTask);
-                                                                    Try<ICloudConnection> cloudConnectionResult = await createTask;
+                                                                    this.cloudConnectionCreateWasRetry = isRetry;
+                                                                    Try<ICloudConnection> cloudConnectionResult;
+                                                                    try
+                                                                    {
+                                                                        cloudConnectionResult = await createTask;
+                                                                    }
+                                                                    finally
+                                                                    {
+                                                                        this.cloudConnectionCreateCompletedTime = Option.Some(this.systemTime.UtcNow);
+                                                                    }
+
                                                                     this.CloudConnection = cloudConnectionResult.Ok();
                                                                     return cloudConnectionResult;
                                                                 });

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -5,7 +5,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Diagnostics;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using App.Metrics;
     using App.Metrics.Gauge;
@@ -32,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         readonly IDeviceConnectivityManager connectivityManager;
         readonly bool closeCloudConnectionOnDeviceDisconnect;
         readonly TimeSpan cloudConnectionRetryInterval;
-        readonly ISystemTime systemTime;
+        readonly Func<long> getTimestamp;
 
         public ConnectionManager(
             ICloudConnectionProvider cloudConnectionProvider,
@@ -49,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 maxClients,
                 closeCloudConnectionOnDeviceDisconnect,
                 DefaultCloudConnectionRetryInterval,
-                SystemTime.Instance)
+                Stopwatch.GetTimestamp)
         {
         }
 
@@ -61,7 +63,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             int maxClients,
             bool closeCloudConnectionOnDeviceDisconnect,
             TimeSpan cloudConnectionRetryInterval,
-            ISystemTime systemTime)
+            Func<long> getTimestamp)
         {
             this.cloudConnectionProvider = Preconditions.CheckNotNull(cloudConnectionProvider, nameof(cloudConnectionProvider));
             this.maxClients = Preconditions.CheckRange(maxClients, 1, nameof(maxClients));
@@ -71,7 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             this.cloudConnectionRetryInterval = cloudConnectionRetryInterval >= TimeSpan.Zero
                 ? cloudConnectionRetryInterval
                 : throw new ArgumentOutOfRangeException(nameof(cloudConnectionRetryInterval));
-            this.systemTime = Preconditions.CheckNotNull(systemTime, nameof(systemTime));
+            this.getTimestamp = Preconditions.CheckNotNull(getTimestamp, nameof(getTimestamp));
             this.connectivityManager.DeviceDisconnected += (o, args) => this.HandleDeviceCloudConnectionDisconnected();
             this.closeCloudConnectionOnDeviceDisconnect = closeCloudConnectionOnDeviceDisconnect;
         }
@@ -119,28 +121,27 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public async Task<Option<ICloudProxy>> GetCloudConnection(string id)
         {
-            Try<ICloudProxy> cloudProxyTry = await this.TryGetCloudConnectionInternal(id, false);
+            Try<ICloudProxy> cloudProxyTry = await this.TryGetCloudConnectionInternal(id);
             return cloudProxyTry
                 .Ok()
-                .Map(c => (ICloudProxy)new RetryingCloudProxy(id, () => this.TryGetCloudConnectionInternal(id, true), c));
+                .Map(c => (ICloudProxy)new RetryingCloudProxy(id, () => this.TryGetCloudConnectionInternal(id), c));
         }
 
         public async Task<Try<ICloudProxy>> TryGetCloudConnection(string id)
         {
-            Try<ICloudProxy> cloudProxyTry = await this.TryGetCloudConnectionInternal(id, false);
+            Try<ICloudProxy> cloudProxyTry = await this.TryGetCloudConnectionInternal(id);
             return cloudProxyTry.Success
-                ? Try.Success((ICloudProxy)new RetryingCloudProxy(id, () => this.TryGetCloudConnectionInternal(id, true), cloudProxyTry.Value))
+                ? Try.Success((ICloudProxy)new RetryingCloudProxy(id, () => this.TryGetCloudConnectionInternal(id), cloudProxyTry.Value))
                 : cloudProxyTry;
         }
 
-        async Task<Try<ICloudProxy>> TryGetCloudConnectionInternal(string id, bool isRetry)
+        async Task<Try<ICloudProxy>> TryGetCloudConnectionInternal(string id)
         {
             IIdentity identity = this.identityProvider.Create(Preconditions.CheckNonWhiteSpace(id, nameof(id)));
             ConnectedDevice device = this.GetOrCreateConnectedDevice(identity);
 
             Try<ICloudConnection> cloudConnectionTry = await device.GetOrCreateCloudConnection(
-                c => this.ConnectToCloud(c.Identity, this.CloudConnectionStatusChangedHandler),
-                isRetry);
+                c => this.ConnectToCloud(c.Identity, this.CloudConnectionStatusChangedHandler));
 
             Events.GetCloudConnection(device.Identity, cloudConnectionTry);
             Try<ICloudProxy> cloudProxyTry = GetCloudProxyFromCloudConnection(cloudConnectionTry, device.Identity);
@@ -250,7 +251,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             Events.NewCloudConnection(credentials.Identity, newCloudConnection);
             Try<ICloudProxy> cloudProxyTry = GetCloudProxyFromCloudConnection(newCloudConnection, credentials.Identity);
             return cloudProxyTry.Success
-                ? Try.Success((ICloudProxy)new RetryingCloudProxy(credentials.Identity.Id, () => this.TryGetCloudConnectionInternal(credentials.Identity.Id, true), cloudProxyTry.Value))
+                ? Try.Success((ICloudProxy)new RetryingCloudProxy(credentials.Identity.Id, () => this.TryGetCloudConnectionInternal(credentials.Identity.Id), cloudProxyTry.Value))
                 : cloudProxyTry;
         }
 
@@ -265,12 +266,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             ConnectedDevice device = this.GetOrCreateConnectedDevice(credentials.Identity);
 
             Try<ICloudConnection> cloudConnectionTry = await device.GetOrCreateCloudConnection(
-                c => this.CreateOrUpdateCloudConnection(c, credentials),
-                false);
+                c => this.CreateOrUpdateCloudConnection(c, credentials));
             Events.GetCloudConnection(credentials.Identity, cloudConnectionTry);
             Try<ICloudProxy> cloudProxyTry = GetCloudProxyFromCloudConnection(cloudConnectionTry, credentials.Identity);
             return cloudProxyTry.Success
-                ? Try.Success((ICloudProxy)new RetryingCloudProxy(credentials.Identity.Id, () => this.TryGetCloudConnectionInternal(credentials.Identity.Id, true), cloudProxyTry.Value))
+                ? Try.Success((ICloudProxy)new RetryingCloudProxy(credentials.Identity.Id, () => this.TryGetCloudConnectionInternal(credentials.Identity.Id), cloudProxyTry.Value))
                 : cloudProxyTry;
         }
 
@@ -279,7 +279,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 .GetOrElse(() => Try<ICloudProxy>.Failure(new EdgeHubConnectionException($"Unable to get cloud proxy for device {identity.Id}")))
             : Try<ICloudProxy>.Failure(cloudConnection.Exception);
 
-        async Task RemoveDeviceConnection(ConnectedDevice device, bool removeCloudConnection)
+        async Task RemoveDeviceConnection(
+            ConnectedDevice device,
+            bool removeCloudConnection,
+            bool throttleReconnect = false)
         {
             var id = device.Identity.Id;
             Events.RemovingDeviceConnection(id, removeCloudConnection);
@@ -288,8 +291,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             if (removeCloudConnection)
             {
-                await device.CloudConnection.Filter(cp => cp.IsActive)
-                    .ForEachAsync(cp => cp.CloseAsync());
+                await device.RemoveCloudConnection(
+                    throttleReconnect,
+                    preserveConnection: throttleReconnect);
             }
 
             Events.RemoveDeviceConnection(id);
@@ -298,7 +302,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         }
 
         Task<Try<ICloudConnection>> CreateOrUpdateCloudConnection(ConnectedDevice device, IClientCredentials credentials) =>
-            device.CloudConnection.Map(
+            device.CloudConnectionForUpdate.Map(
                     async c =>
                     {
                         try
@@ -350,7 +354,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                                     Try<ICloudConnection> cloudConnectionTry = await device.CreateOrUpdateCloudConnection(c => this.CreateOrUpdateCloudConnection(c, tokenCredentials));
                                     if (!cloudConnectionTry.Success)
                                     {
-                                        await this.RemoveDeviceConnection(device, true);
+                                        await this.RemoveDeviceConnection(device, true, true);
                                         this.CloudConnectionLost?.Invoke(this, device.Identity);
                                     }
                                 }
@@ -362,14 +366,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     }
                     else
                     {
-                        await this.RemoveDeviceConnection(device, true);
+                        await this.RemoveDeviceConnection(device, true, true);
                         this.CloudConnectionLost?.Invoke(this, device.Identity);
                     }
 
                     break;
 
                 case CloudConnectionStatus.DisconnectedTokenExpired:
-                    await this.RemoveDeviceConnection(device, true);
+                    await this.RemoveDeviceConnection(device, true, true);
                     Events.InvokingCloudConnectionLostEvent(device.Identity);
                     this.CloudConnectionLost?.Invoke(this, device.Identity);
                     break;
@@ -388,18 +392,21 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         async void HandleDeviceCloudConnectionDisconnected()
         {
+            KeyValuePair<string, ConnectedDevice>[] snapshot;
             using (await this.connectToCloudLock.WriterLockAsync())
             {
-                KeyValuePair<string, ConnectedDevice>[] snapshot = this.devices.ToArray();
+                snapshot = this.devices.ToArray();
                 Events.CloudConnectionLostClosingAllClients();
                 foreach (var item in snapshot)
                 {
-                    await item.Value.CloudConnection.Filter(cp => cp.IsActive).ForEachAsync(
-                        cp =>
-                        {
-                            Events.CloudConnectionLostClosingClient(item.Value.Identity);
-                            return cp.CloseAsync();
-                        });
+                    if (item.Value.CloudConnection.Filter(cp => cp.IsActive).HasValue)
+                    {
+                        Events.CloudConnectionLostClosingClient(item.Value.Identity);
+                    }
+
+                    await item.Value.RemoveCloudConnection(
+                        throttleReconnect: false,
+                        preserveConnection: false);
                 }
             }
         }
@@ -419,12 +426,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             return this.devices.AddOrUpdate(
                 deviceId,
                 id => this.CreateNewConnectedDevice(identity),
-                (id, cd) => new ConnectedDevice(
-                    identity,
-                    cd.CloudConnection,
-                    cd.DeviceConnection,
-                    this.cloudConnectionRetryInterval,
-                    this.systemTime));
+                (id, cd) =>
+                {
+                    cd.UpdateIdentity(identity);
+                    return cd;
+                });
         }
 
         ConnectedDevice CreateNewConnectedDevice(IIdentity identity)
@@ -436,7 +442,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     throw new EdgeHubConnectionException($"Edge hub already has maximum allowed clients ({this.maxClients - 1}) connected.");
                 }
 
-                return new ConnectedDevice(identity, this.cloudConnectionRetryInterval, this.systemTime);
+                return new ConnectedDevice(identity, this.cloudConnectionRetryInterval, this.getTimestamp);
             }
         }
 
@@ -461,20 +467,29 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             // Device Proxy methods are sync coming from the Protocol gateway,
             // so using traditional locking mechanism for those.
             readonly object deviceProxyLock = new object();
+            readonly object cloudConnectionStateLock = new object();
             readonly AsyncLock cloudConnectionLock = new AsyncLock();
+            readonly AsyncLock cloudConnectionRemovalLock = new AsyncLock();
             readonly TimeSpan cloudConnectionRetryInterval;
-            readonly ISystemTime systemTime;
-            Option<Task<Try<ICloudConnection>>> cloudConnectionCreateTask = Option.None<Task<Try<ICloudConnection>>>();
-            Option<DateTime> cloudConnectionCreateCompletedTime = Option.None<DateTime>();
-            bool cloudConnectionCreateWasRetry;
+            readonly Func<long> getTimestamp;
+            ICloudConnection cloudConnection;
+            ICloudConnection preservedCloudConnection;
+            DeviceConnection deviceConnection;
+            IIdentity identity;
+            Task<Try<ICloudConnection>> cloudConnectionCreateTask;
+            long cloudConnectionCreateGeneration;
+            long cloudConnectionCreateCompletedTimestamp;
+            long cloudConnectionGeneration;
+            bool hasCloudConnectionCreateCompletedTimestamp;
+            bool shouldThrottleCloudConnectionCreation;
 
-            public ConnectedDevice(IIdentity identity, TimeSpan cloudConnectionRetryInterval, ISystemTime systemTime)
+            public ConnectedDevice(IIdentity identity, TimeSpan cloudConnectionRetryInterval, Func<long> getTimestamp)
                 : this(
                     identity,
                     Option.None<ICloudConnection>(),
                     Option.None<DeviceConnection>(),
                     cloudConnectionRetryInterval,
-                    systemTime)
+                    getTimestamp)
             {
             }
 
@@ -483,30 +498,71 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 Option<ICloudConnection> cloudProxy,
                 Option<DeviceConnection> deviceConnection,
                 TimeSpan cloudConnectionRetryInterval,
-                ISystemTime systemTime)
+                Func<long> getTimestamp)
             {
-                this.Identity = identity;
-                this.CloudConnection = cloudProxy;
-                this.DeviceConnection = deviceConnection;
+                this.identity = identity;
+                this.cloudConnection = cloudProxy.OrDefault();
+                this.deviceConnection = deviceConnection.OrDefault();
                 this.cloudConnectionRetryInterval = cloudConnectionRetryInterval;
-                this.systemTime = systemTime;
+                this.getTimestamp = getTimestamp;
             }
 
-            public IIdentity Identity { get; }
+            public IIdentity Identity => Volatile.Read(ref this.identity);
 
-            public Option<ICloudConnection> CloudConnection { get; private set; }
+            public Option<ICloudConnection> CloudConnection
+            {
+                get
+                {
+                    ICloudConnection currentCloudConnection = Volatile.Read(ref this.cloudConnection);
+                    return currentCloudConnection != null
+                        ? Option.Some(currentCloudConnection)
+                        : Option.None<ICloudConnection>();
+                }
+            }
+
+            public Option<ICloudConnection> CloudConnectionForUpdate
+            {
+                get
+                {
+                    ICloudConnection currentCloudConnection = Volatile.Read(ref this.cloudConnection)
+                        ?? Volatile.Read(ref this.preservedCloudConnection);
+                    return currentCloudConnection != null
+                        ? Option.Some(currentCloudConnection)
+                        : Option.None<ICloudConnection>();
+                }
+            }
 
             // ReSharper disable once MemberHidesStaticFromOuterClass
-            public Option<DeviceConnection> DeviceConnection { get; private set; }
+            public Option<DeviceConnection> DeviceConnection
+            {
+                get
+                {
+                    DeviceConnection currentDeviceConnection = Volatile.Read(ref this.deviceConnection);
+                    return currentDeviceConnection != null
+                        ? Option.Some(currentDeviceConnection)
+                        : Option.None<DeviceConnection>();
+                }
+            }
+
+            public void UpdateIdentity(IIdentity identity)
+            {
+                Volatile.Write(ref this.identity, Preconditions.CheckNotNull(identity, nameof(identity)));
+            }
 
             public Option<DeviceConnection> AddDeviceConnection(IDeviceProxy deviceProxy)
             {
                 Preconditions.CheckNotNull(deviceProxy, nameof(deviceProxy));
                 lock (this.deviceProxyLock)
                 {
-                    Option<DeviceConnection> currentValue = this.DeviceConnection;
-                    this.DeviceConnection = Option.Some(new DeviceConnection(deviceProxy, new ConcurrentDictionary<DeviceSubscription, bool>()));
-                    return currentValue;
+                    DeviceConnection newDeviceConnection = new DeviceConnection(
+                        deviceProxy,
+                        new ConcurrentDictionary<DeviceSubscription, bool>());
+                    DeviceConnection currentDeviceConnection = Interlocked.Exchange(
+                        ref this.deviceConnection,
+                        newDeviceConnection);
+                    return currentDeviceConnection != null
+                        ? Option.Some(currentDeviceConnection)
+                        : Option.None<DeviceConnection>();
                 }
             }
 
@@ -514,25 +570,44 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 Func<ConnectedDevice, Task<Try<ICloudConnection>>> cloudConnectionUpdater)
             {
                 Preconditions.CheckNotNull(cloudConnectionUpdater, nameof(cloudConnectionUpdater));
+                await this.WaitForCloudConnectionRemoval();
                 // Lock in case multiple connections are created to the cloud for the same device at the same time
                 using (await this.cloudConnectionLock.LockAsync())
                 {
-                    Task<Try<ICloudConnection>> updateTask = cloudConnectionUpdater(this);
-                    this.cloudConnectionCreateTask = Option.Some(updateTask);
-                    this.cloudConnectionCreateWasRetry = false;
-                    Try<ICloudConnection> newCloudConnection;
-                    try
+                    long connectionGeneration = Volatile.Read(ref this.cloudConnectionGeneration);
+                    Try<ICloudConnection> newCloudConnection = await cloudConnectionUpdater(this);
+                    bool invalidated;
+                    lock (this.cloudConnectionStateLock)
                     {
-                        newCloudConnection = await updateTask;
-                    }
-                    finally
-                    {
-                        this.cloudConnectionCreateCompletedTime = Option.Some(this.systemTime.UtcNow);
+                        invalidated = !this.IsCloudConnectionGenerationValid(connectionGeneration);
+                        if (!invalidated)
+                        {
+                            if (newCloudConnection.Success)
+                            {
+                                Volatile.Write(ref this.cloudConnection, newCloudConnection.Value);
+                                Interlocked.CompareExchange(
+                                    ref this.preservedCloudConnection,
+                                    null,
+                                    newCloudConnection.Value);
+                            }
+
+                            if (newCloudConnection.Success && newCloudConnection.Value.IsActive)
+                            {
+                                this.ResetCloudConnectionRetryStateCore(connectionGeneration);
+                            }
+                            else
+                            {
+                                this.RecordCloudConnectionAttemptCore(
+                                    Task.FromResult(newCloudConnection),
+                                    true,
+                                    connectionGeneration);
+                            }
+                        }
                     }
 
-                    if (newCloudConnection.Success)
+                    if (invalidated)
                     {
-                        this.CloudConnection = Option.Some(newCloudConnection.Value);
+                        return await this.DiscardInvalidatedCloudConnection(newCloudConnection);
                     }
 
                     return newCloudConnection;
@@ -540,55 +615,337 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             }
 
             public async Task<Try<ICloudConnection>> GetOrCreateCloudConnection(
-                Func<ConnectedDevice, Task<Try<ICloudConnection>>> cloudConnectionCreator,
-                bool isRetry)
+                Func<ConnectedDevice, Task<Try<ICloudConnection>>> cloudConnectionCreator)
             {
                 Preconditions.CheckNotNull(cloudConnectionCreator, nameof(cloudConnectionCreator));
 
-                return await this.CloudConnection.Filter(cp => cp.IsActive)
-                    .Map(c => Task.FromResult(Try.Success(c)))
-                    .GetOrElse(
-                        async () =>
-                        {
-                            return await this.cloudConnectionCreateTask.Filter(c => !c.IsCompleted)
-                                .GetOrElse(
-                                    async () =>
-                                    {
-                                        using (await this.cloudConnectionLock.LockAsync())
-                                        {
-                                            return await this.CloudConnection.Filter(cp => cp.IsActive)
-                                                .Map(c => Task.FromResult(Try.Success(c)))
-                                                .GetOrElse(
-                                                    async () =>
-                                                    {
-                                                        bool retryIntervalElapsed = this.cloudConnectionCreateCompletedTime
-                                                            .Map(t => this.systemTime.UtcNow - t >= this.cloudConnectionRetryInterval)
-                                                            .GetOrElse(true);
-                                                        return await this.cloudConnectionCreateTask.Filter(
-                                                                c => !c.IsCompleted || this.cloudConnectionCreateWasRetry && !retryIntervalElapsed)
-                                                            .GetOrElse(
-                                                                async () =>
-                                                                {
-                                                                    Task<Try<ICloudConnection>> createTask = cloudConnectionCreator(this);
-                                                                    this.cloudConnectionCreateTask = Option.Some(createTask);
-                                                                    this.cloudConnectionCreateWasRetry = isRetry;
-                                                                    Try<ICloudConnection> cloudConnectionResult;
-                                                                    try
-                                                                    {
-                                                                        cloudConnectionResult = await createTask;
-                                                                    }
-                                                                    finally
-                                                                    {
-                                                                        this.cloudConnectionCreateCompletedTime = Option.Some(this.systemTime.UtcNow);
-                                                                    }
+                long connectionGeneration = Volatile.Read(ref this.cloudConnectionGeneration);
+                Task<Try<ICloudConnection>> createTask = Volatile.Read(ref this.cloudConnectionCreateTask);
+                if (createTask != null
+                    && !createTask.IsCompleted
+                    && this.IsCloudConnectionGenerationValid(connectionGeneration)
+                    && connectionGeneration == Volatile.Read(ref this.cloudConnectionCreateGeneration))
+                {
+                    return await createTask;
+                }
 
-                                                                    this.CloudConnection = cloudConnectionResult.Ok();
-                                                                    return cloudConnectionResult;
-                                                                });
-                                                    });
-                                        }
-                                    });
-                        });
+                using (await this.cloudConnectionLock.LockAsync())
+                {
+                    lock (this.cloudConnectionStateLock)
+                    {
+                        connectionGeneration = Volatile.Read(ref this.cloudConnectionGeneration);
+                        Option<ICloudConnection> activeCloudConnection = this.CloudConnection.Filter(cp => cp.IsActive);
+                        if (this.IsCloudConnectionGenerationValid(connectionGeneration)
+                            && activeCloudConnection.HasValue)
+                        {
+                            return Try.Success(activeCloudConnection.OrDefault());
+                        }
+                    }
+
+                    bool reuseCreateTask = false;
+                    lock (this.cloudConnectionStateLock)
+                    {
+                        connectionGeneration = Volatile.Read(ref this.cloudConnectionGeneration);
+                        if (!this.IsCloudConnectionGenerationValid(connectionGeneration))
+                        {
+                            return Try<ICloudConnection>.Failure(
+                                new EdgeHubConnectionException($"Cloud connection for device {this.Identity.Id} is being removed."));
+                        }
+
+                        createTask = this.cloudConnectionCreateTask;
+                        if (createTask != null && connectionGeneration == this.cloudConnectionCreateGeneration)
+                        {
+                            reuseCreateTask = !createTask.IsCompleted
+                                || this.shouldThrottleCloudConnectionCreation
+                                && !this.CloudConnectionRetryIntervalElapsed();
+                            if (reuseCreateTask && createTask.IsCompleted)
+                            {
+                                Events.ReusingRecentCloudConnectionAttempt(this.Identity, this.cloudConnectionRetryInterval);
+                            }
+                        }
+
+                        if (!reuseCreateTask)
+                        {
+                            bool replacesExistingConnection = this.CloudConnectionForUpdate.HasValue;
+                            Volatile.Write(ref this.cloudConnectionCreateGeneration, connectionGeneration);
+                            createTask = this.CreateCloudConnection(
+                                cloudConnectionCreator,
+                                replacesExistingConnection,
+                                connectionGeneration);
+                            Volatile.Write(ref this.cloudConnectionCreateTask, createTask);
+                        }
+                    }
+
+                    return await createTask;
+                }
+            }
+
+            async Task<Try<ICloudConnection>> CreateCloudConnection(
+                Func<ConnectedDevice, Task<Try<ICloudConnection>>> cloudConnectionCreator,
+                bool replacesExistingConnection,
+                long connectionGeneration)
+            {
+                Task<Try<ICloudConnection>> createTask = null;
+                try
+                {
+                    createTask = cloudConnectionCreator(this);
+                    Try<ICloudConnection> cloudConnectionResult = await createTask;
+                    bool invalidated;
+                    ICloudConnection displacedPreservedConnection = null;
+                    lock (this.cloudConnectionStateLock)
+                    {
+                        invalidated = !this.IsCloudConnectionGenerationValid(connectionGeneration);
+                        if (!invalidated)
+                        {
+                            Volatile.Write(
+                                ref this.cloudConnection,
+                                cloudConnectionResult.Success ? cloudConnectionResult.Value : null);
+                            if (cloudConnectionResult.Success)
+                            {
+                                displacedPreservedConnection = Interlocked.Exchange(
+                                    ref this.preservedCloudConnection,
+                                    null);
+                            }
+
+                            this.shouldThrottleCloudConnectionCreation = replacesExistingConnection
+                                || !cloudConnectionResult.Success
+                                || !cloudConnectionResult.Value.IsActive;
+                        }
+                    }
+
+                    if (invalidated)
+                    {
+                        return await this.DiscardInvalidatedCloudConnection(cloudConnectionResult);
+                    }
+
+                    if (displacedPreservedConnection != null
+                        && !ReferenceEquals(displacedPreservedConnection, cloudConnectionResult.Value))
+                    {
+                        if (displacedPreservedConnection is IClientTokenCloudConnection clientTokenCloudConnection)
+                        {
+                            clientTokenCloudConnection.CancelTokenUpdate();
+                        }
+
+                        await displacedPreservedConnection.CloseAsync();
+                    }
+
+                    return cloudConnectionResult;
+                }
+                finally
+                {
+                    lock (this.cloudConnectionStateLock)
+                    {
+                        if (this.IsCloudConnectionGenerationValid(connectionGeneration))
+                        {
+                            this.cloudConnectionCreateCompletedTimestamp = this.getTimestamp();
+                            this.hasCloudConnectionCreateCompletedTimestamp = true;
+                            if (createTask == null || createTask.IsFaulted || createTask.IsCanceled)
+                            {
+                                this.shouldThrottleCloudConnectionCreation = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            async Task WaitForCloudConnectionRemoval()
+            {
+                using (await this.cloudConnectionRemovalLock.LockAsync())
+                {
+                }
+            }
+
+            bool CloudConnectionRetryIntervalElapsed()
+            {
+                if (!this.hasCloudConnectionCreateCompletedTimestamp)
+                {
+                    return true;
+                }
+
+                long elapsedTimestamp = this.getTimestamp() - this.cloudConnectionCreateCompletedTimestamp;
+                return elapsedTimestamp < 0
+                    || elapsedTimestamp >= this.cloudConnectionRetryInterval.TotalSeconds * Stopwatch.Frequency;
+            }
+
+            void RecordCloudConnectionAttemptCore(
+                Task<Try<ICloudConnection>> createTask,
+                bool shouldThrottle,
+                long connectionGeneration)
+            {
+                if (!this.IsCloudConnectionGenerationValid(connectionGeneration))
+                {
+                    return;
+                }
+
+                Volatile.Write(ref this.cloudConnectionCreateGeneration, connectionGeneration);
+                Volatile.Write(ref this.cloudConnectionCreateTask, createTask);
+                this.cloudConnectionCreateCompletedTimestamp = this.getTimestamp();
+                this.hasCloudConnectionCreateCompletedTimestamp = true;
+                this.shouldThrottleCloudConnectionCreation = shouldThrottle;
+            }
+
+            void ResetCloudConnectionRetryStateCore(long connectionGeneration)
+            {
+                if (!this.IsCloudConnectionGenerationValid(connectionGeneration))
+                {
+                    return;
+                }
+
+                Volatile.Write(ref this.cloudConnectionCreateGeneration, connectionGeneration);
+                Volatile.Write(ref this.cloudConnectionCreateTask, null);
+                this.cloudConnectionCreateCompletedTimestamp = 0;
+                this.hasCloudConnectionCreateCompletedTimestamp = false;
+                this.shouldThrottleCloudConnectionCreation = false;
+            }
+
+            public async Task RemoveCloudConnection(
+                bool throttleReconnect,
+                bool preserveConnection)
+            {
+                using (await this.cloudConnectionRemovalLock.LockAsync())
+                {
+                    var removedCloudConnections = new List<ICloudConnection>(2);
+                    var supersededCloudConnections = new List<ICloudConnection>(1);
+                    lock (this.cloudConnectionStateLock)
+                    {
+                        Interlocked.Increment(ref this.cloudConnectionGeneration);
+                        ICloudConnection activeCloudConnection =
+                            Interlocked.Exchange(ref this.cloudConnection, null);
+                        if (activeCloudConnection != null)
+                        {
+                            removedCloudConnections.Add(activeCloudConnection);
+                        }
+
+                        if (preserveConnection)
+                        {
+                            if (activeCloudConnection != null)
+                            {
+                                ICloudConnection previousPreservedConnection =
+                                    Interlocked.Exchange(
+                                        ref this.preservedCloudConnection,
+                                        activeCloudConnection);
+                                if (previousPreservedConnection != null
+                                    && !ReferenceEquals(previousPreservedConnection, activeCloudConnection))
+                                {
+                                    supersededCloudConnections.Add(previousPreservedConnection);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            ICloudConnection preservedConnection =
+                                Interlocked.Exchange(ref this.preservedCloudConnection, null);
+                            if (preservedConnection != null
+                                && !ReferenceEquals(preservedConnection, activeCloudConnection))
+                            {
+                                removedCloudConnections.Add(preservedConnection);
+                            }
+                        }
+                    }
+
+                    try
+                    {
+                        foreach (ICloudConnection supersededCloudConnection in supersededCloudConnections)
+                        {
+                            if (supersededCloudConnection is IClientTokenCloudConnection clientTokenCloudConnection)
+                            {
+                                clientTokenCloudConnection.CancelTokenUpdate();
+                            }
+
+                            if (supersededCloudConnection.IsActive)
+                            {
+                                await supersededCloudConnection.CloseAsync();
+                            }
+                        }
+
+                        foreach (ICloudConnection removedCloudConnection in removedCloudConnections)
+                        {
+                            bool preserveForTokenUpdate = false;
+                            if (removedCloudConnection is IClientTokenCloudConnection clientTokenCloudConnection)
+                            {
+                                if (!preserveConnection)
+                                {
+                                    clientTokenCloudConnection.CancelTokenUpdate();
+                                }
+                                else if (clientTokenCloudConnection.HasPendingTokenUpdate)
+                                {
+                                    preserveForTokenUpdate = true;
+                                }
+                                else
+                                {
+                                    clientTokenCloudConnection.CancelTokenUpdate();
+                                }
+                            }
+
+                            if (preserveForTokenUpdate)
+                            {
+                                continue;
+                            }
+
+                            if (preserveConnection)
+                            {
+                                Interlocked.CompareExchange(
+                                    ref this.preservedCloudConnection,
+                                    null,
+                                    removedCloudConnection);
+                            }
+
+                            if (removedCloudConnection.IsActive)
+                            {
+                                await removedCloudConnection.CloseAsync();
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        lock (this.cloudConnectionStateLock)
+                        {
+                            long stableGeneration = Volatile.Read(ref this.cloudConnectionGeneration) + 1;
+                            Volatile.Write(ref this.cloudConnectionCreateGeneration, stableGeneration);
+                            this.cloudConnectionCreateCompletedTimestamp = this.getTimestamp();
+                            this.hasCloudConnectionCreateCompletedTimestamp = throttleReconnect;
+                            this.shouldThrottleCloudConnectionCreation = throttleReconnect;
+                            Volatile.Write(
+                                ref this.cloudConnectionCreateTask,
+                                throttleReconnect
+                                    ? Task.FromResult(
+                                        Try<ICloudConnection>.Failure(
+                                            new EdgeHubConnectionException(
+                                                $"Cloud connection for device {this.Identity.Id} was removed after a cloud failure.")))
+                                    : null);
+                            Interlocked.Increment(ref this.cloudConnectionGeneration);
+                        }
+                    }
+                }
+            }
+
+            bool IsCloudConnectionGenerationValid(long connectionGeneration) =>
+                (connectionGeneration & 1) == 0
+                && connectionGeneration == Volatile.Read(ref this.cloudConnectionGeneration);
+
+            async Task<Try<ICloudConnection>> DiscardInvalidatedCloudConnection(
+                Try<ICloudConnection> cloudConnection)
+            {
+                if (cloudConnection.Success)
+                {
+                    Interlocked.CompareExchange(
+                        ref this.cloudConnection,
+                        null,
+                        cloudConnection.Value);
+                    Interlocked.CompareExchange(
+                        ref this.preservedCloudConnection,
+                        null,
+                        cloudConnection.Value);
+                    if (cloudConnection.Value is IClientTokenCloudConnection clientTokenCloudConnection)
+                    {
+                        clientTokenCloudConnection.CancelTokenUpdate();
+                    }
+
+                    await cloudConnection.Value.CloseAsync();
+                }
+
+                return Try<ICloudConnection>.Failure(
+                    new EdgeHubConnectionException($"Cloud connection attempt for device {this.Identity.Id} was invalidated."));
             }
         }
 
@@ -629,7 +986,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 HandlingConnectionStatusChangedHandler,
                 CloudConnectionLostClosingClient,
                 CloudConnectionLostClosingAllClients,
-                GettingCloudConnectionForDeviceSubscriptions
+                GettingCloudConnectionForDeviceSubscriptions,
+                ReusingRecentCloudConnectionAttempt
             }
 
             public static void NewCloudConnection(IIdentity identity, Try<ICloudConnection> cloudConnection)
@@ -704,6 +1062,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             public static void GettingCloudConnectionForDeviceSubscriptions()
             {
                 Log.LogDebug((int)EventIds.GettingCloudConnectionForDeviceSubscriptions, $"Device has subscriptions. Trying to get cloud connection.");
+            }
+
+            public static void ReusingRecentCloudConnectionAttempt(IIdentity identity, TimeSpan retryInterval)
+            {
+                Log.LogDebug(
+                    (int)EventIds.ReusingRecentCloudConnectionAttempt,
+                    Invariant($"Reusing recent cloud connection attempt for device {identity.Id} during {retryInterval} retry interval."));
             }
         }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -656,8 +656,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                         if (createTask != null && connectionGeneration == this.cloudConnectionCreateGeneration)
                         {
                             reuseCreateTask = !createTask.IsCompleted
-                                || this.shouldThrottleCloudConnectionCreation
-                                && !this.CloudConnectionRetryIntervalElapsed();
+                                || (this.shouldThrottleCloudConnectionCreation
+                                    && !this.CloudConnectionRetryIntervalElapsed());
                             if (reuseCreateTask && createTask.IsCompleted)
                             {
                                 Events.ReusingRecentCloudConnectionAttempt(this.Identity, this.cloudConnectionRetryInterval);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     {
         const int DefaultMaxClients = 101; // 100 Clients + 1 Edgehub
         static readonly TimeSpan DefaultCloudConnectionRetryInterval = TimeSpan.FromSeconds(5);
+
+        // Retry throttling must not be skewed by wall-clock jumps, so it is measured against a
+        // process-wide monotonic clock.
+        static readonly Stopwatch MonotonicClock = Stopwatch.StartNew();
+
         readonly object deviceConnLock = new object();
         readonly AsyncReaderWriterLock connectToCloudLock = new AsyncReaderWriterLock();
         readonly ConcurrentDictionary<string, ConnectedDevice> devices = new ConcurrentDictionary<string, ConnectedDevice>();
@@ -34,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         readonly IDeviceConnectivityManager connectivityManager;
         readonly bool closeCloudConnectionOnDeviceDisconnect;
         readonly TimeSpan cloudConnectionRetryInterval;
-        readonly Func<long> getTimestamp;
+        readonly Func<TimeSpan> getMonotonicTime;
 
         public ConnectionManager(
             ICloudConnectionProvider cloudConnectionProvider,
@@ -51,7 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 maxClients,
                 closeCloudConnectionOnDeviceDisconnect,
                 DefaultCloudConnectionRetryInterval,
-                Stopwatch.GetTimestamp)
+                () => MonotonicClock.Elapsed)
         {
         }
 
@@ -63,7 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             int maxClients,
             bool closeCloudConnectionOnDeviceDisconnect,
             TimeSpan cloudConnectionRetryInterval,
-            Func<long> getTimestamp)
+            Func<TimeSpan> getMonotonicTime)
         {
             this.cloudConnectionProvider = Preconditions.CheckNotNull(cloudConnectionProvider, nameof(cloudConnectionProvider));
             this.maxClients = Preconditions.CheckRange(maxClients, 1, nameof(maxClients));
@@ -73,7 +78,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             this.cloudConnectionRetryInterval = cloudConnectionRetryInterval >= TimeSpan.Zero
                 ? cloudConnectionRetryInterval
                 : throw new ArgumentOutOfRangeException(nameof(cloudConnectionRetryInterval));
-            this.getTimestamp = Preconditions.CheckNotNull(getTimestamp, nameof(getTimestamp));
+            this.getMonotonicTime = Preconditions.CheckNotNull(getMonotonicTime, nameof(getMonotonicTime));
             this.connectivityManager.DeviceDisconnected += (o, args) => this.HandleDeviceCloudConnectionDisconnected();
             this.closeCloudConnectionOnDeviceDisconnect = closeCloudConnectionOnDeviceDisconnect;
         }
@@ -108,7 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public Task RemoveDeviceConnection(string id)
         {
             return this.devices.TryGetValue(Preconditions.CheckNonWhiteSpace(id, nameof(id)), out ConnectedDevice device)
-                ? this.RemoveDeviceConnection(device, this.closeCloudConnectionOnDeviceDisconnect)
+                ? this.RemoveDeviceConnection(device, removeCloudConnection: this.closeCloudConnectionOnDeviceDisconnect)
                 : Task.CompletedTask;
         }
 
@@ -292,7 +297,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             if (removeCloudConnection)
             {
                 await device.RemoveCloudConnection(
-                    throttleReconnect,
+                    throttleReconnect: throttleReconnect,
                     preserveConnection: throttleReconnect);
             }
 
@@ -354,26 +359,26 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                                     Try<ICloudConnection> cloudConnectionTry = await device.CreateOrUpdateCloudConnection(c => this.CreateOrUpdateCloudConnection(c, tokenCredentials));
                                     if (!cloudConnectionTry.Success)
                                     {
-                                        await this.RemoveDeviceConnection(device, true, true);
+                                        await this.RemoveDeviceConnection(device, removeCloudConnection: true, throttleReconnect: true);
                                         this.CloudConnectionLost?.Invoke(this, device.Identity);
                                     }
                                 }
                                 else
                                 {
-                                    await this.RemoveDeviceConnection(device, this.closeCloudConnectionOnDeviceDisconnect);
+                                    await this.RemoveDeviceConnection(device, removeCloudConnection: this.closeCloudConnectionOnDeviceDisconnect);
                                 }
                             });
                     }
                     else
                     {
-                        await this.RemoveDeviceConnection(device, true, true);
+                        await this.RemoveDeviceConnection(device, removeCloudConnection: true, throttleReconnect: true);
                         this.CloudConnectionLost?.Invoke(this, device.Identity);
                     }
 
                     break;
 
                 case CloudConnectionStatus.DisconnectedTokenExpired:
-                    await this.RemoveDeviceConnection(device, true, true);
+                    await this.RemoveDeviceConnection(device, removeCloudConnection: true, throttleReconnect: true);
                     Events.InvokingCloudConnectionLostEvent(device.Identity);
                     this.CloudConnectionLost?.Invoke(this, device.Identity);
                     break;
@@ -442,7 +447,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     throw new EdgeHubConnectionException($"Edge hub already has maximum allowed clients ({this.maxClients - 1}) connected.");
                 }
 
-                return new ConnectedDevice(identity, this.cloudConnectionRetryInterval, this.getTimestamp);
+                return new ConnectedDevice(identity, this.cloudConnectionRetryInterval, this.getMonotonicTime);
             }
         }
 
@@ -464,6 +469,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         class ConnectedDevice
         {
+            // Generation parity is the removal flag: even means the cloud connection state is stable,
+            // odd means a removal is in progress. A connection attempt captures the generation it
+            // started under and may only publish its result while that generation is still current,
+            // so any interleaving removal discards it.
+            const long RemovalInProgressBit = 1;
+
             // Device Proxy methods are sync coming from the Protocol gateway,
             // so using traditional locking mechanism for those.
             readonly object deviceProxyLock = new object();
@@ -471,40 +482,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             readonly AsyncLock cloudConnectionLock = new AsyncLock();
             readonly AsyncLock cloudConnectionRemovalLock = new AsyncLock();
             readonly TimeSpan cloudConnectionRetryInterval;
-            readonly Func<long> getTimestamp;
+            readonly Func<TimeSpan> getMonotonicTime;
             ICloudConnection cloudConnection;
             ICloudConnection preservedCloudConnection;
             DeviceConnection deviceConnection;
             IIdentity identity;
             Task<Try<ICloudConnection>> cloudConnectionCreateTask;
             long cloudConnectionCreateGeneration;
-            long cloudConnectionCreateCompletedTimestamp;
             long cloudConnectionGeneration;
-            bool hasCloudConnectionCreateCompletedTimestamp;
+            TimeSpan? cloudConnectionCreateCompletedTime;
             bool shouldThrottleCloudConnectionCreation;
 
-            public ConnectedDevice(IIdentity identity, TimeSpan cloudConnectionRetryInterval, Func<long> getTimestamp)
-                : this(
-                    identity,
-                    Option.None<ICloudConnection>(),
-                    Option.None<DeviceConnection>(),
-                    cloudConnectionRetryInterval,
-                    getTimestamp)
-            {
-            }
-
-            public ConnectedDevice(
-                IIdentity identity,
-                Option<ICloudConnection> cloudProxy,
-                Option<DeviceConnection> deviceConnection,
-                TimeSpan cloudConnectionRetryInterval,
-                Func<long> getTimestamp)
+            public ConnectedDevice(IIdentity identity, TimeSpan cloudConnectionRetryInterval, Func<TimeSpan> getMonotonicTime)
             {
                 this.identity = identity;
-                this.cloudConnection = cloudProxy.OrDefault();
-                this.deviceConnection = deviceConnection.OrDefault();
                 this.cloudConnectionRetryInterval = cloudConnectionRetryInterval;
-                this.getTimestamp = getTimestamp;
+                this.getMonotonicTime = getMonotonicTime;
             }
 
             public IIdentity Identity => Volatile.Read(ref this.identity);
@@ -570,7 +563,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 Func<ConnectedDevice, Task<Try<ICloudConnection>>> cloudConnectionUpdater)
             {
                 Preconditions.CheckNotNull(cloudConnectionUpdater, nameof(cloudConnectionUpdater));
-                await this.WaitForCloudConnectionRemoval();
+                await this.WaitForPendingCloudConnectionRemoval();
                 // Lock in case multiple connections are created to the cloud for the same device at the same time
                 using (await this.cloudConnectionLock.LockAsync())
                 {
@@ -597,9 +590,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                             }
                             else
                             {
-                                this.RecordCloudConnectionAttemptCore(
+                                this.RecordFailedCloudConnectionAttemptCore(
                                     Task.FromResult(newCloudConnection),
-                                    true,
                                     connectionGeneration);
                             }
                         }
@@ -642,7 +634,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                         }
                     }
 
-                    bool reuseCreateTask = false;
+                    TaskCompletionSource<Try<ICloudConnection>> createTaskSource = null;
+                    bool replacesExistingConnection = false;
                     lock (this.cloudConnectionStateLock)
                     {
                         connectionGeneration = Volatile.Read(ref this.cloudConnectionGeneration);
@@ -652,6 +645,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                                 new EdgeHubConnectionException($"Cloud connection for device {this.Identity.Id} is being removed."));
                         }
 
+                        bool reuseCreateTask = false;
                         createTask = this.cloudConnectionCreateTask;
                         if (createTask != null && connectionGeneration == this.cloudConnectionCreateGeneration)
                         {
@@ -666,13 +660,30 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
                         if (!reuseCreateTask)
                         {
-                            bool replacesExistingConnection = this.CloudConnectionForUpdate.HasValue;
+                            replacesExistingConnection = this.CloudConnectionForUpdate.HasValue;
+                            // Publish the placeholder under the lock so concurrent callers join this attempt,
+                            // but run the caller-supplied creator only after the lock is released.
+                            createTaskSource = new TaskCompletionSource<Try<ICloudConnection>>(
+                                TaskCreationOptions.RunContinuationsAsynchronously);
+                            createTask = createTaskSource.Task;
                             Volatile.Write(ref this.cloudConnectionCreateGeneration, connectionGeneration);
-                            createTask = this.CreateCloudConnection(
-                                cloudConnectionCreator,
-                                replacesExistingConnection,
-                                connectionGeneration);
                             Volatile.Write(ref this.cloudConnectionCreateTask, createTask);
+                        }
+                    }
+
+                    if (createTaskSource != null)
+                    {
+                        try
+                        {
+                            createTaskSource.SetResult(
+                                await this.CreateCloudConnection(
+                                    cloudConnectionCreator,
+                                    replacesExistingConnection,
+                                    connectionGeneration));
+                        }
+                        catch (Exception ex)
+                        {
+                            createTaskSource.SetException(ex);
                         }
                     }
 
@@ -721,12 +732,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     if (displacedPreservedConnection != null
                         && !ReferenceEquals(displacedPreservedConnection, cloudConnectionResult.Value))
                     {
-                        if (displacedPreservedConnection is IClientTokenCloudConnection clientTokenCloudConnection)
-                        {
-                            clientTokenCloudConnection.CancelTokenUpdate();
-                        }
-
-                        await displacedPreservedConnection.CloseAsync();
+                        await CancelTokenUpdateAndCloseAsync(displacedPreservedConnection);
                     }
 
                     return cloudConnectionResult;
@@ -737,8 +743,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     {
                         if (this.IsCloudConnectionGenerationValid(connectionGeneration))
                         {
-                            this.cloudConnectionCreateCompletedTimestamp = this.getTimestamp();
-                            this.hasCloudConnectionCreateCompletedTimestamp = true;
+                            this.cloudConnectionCreateCompletedTime = this.getMonotonicTime();
                             if (createTask == null || createTask.IsFaulted || createTask.IsCanceled)
                             {
                                 this.shouldThrottleCloudConnectionCreation = true;
@@ -748,7 +753,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 }
             }
 
-            async Task WaitForCloudConnectionRemoval()
+            // Barrier: acquiring and immediately releasing the removal lock guarantees that a removal
+            // already in flight has published its final generation and throttle state before the caller
+            // reads them. The lock is deliberately not held across the caller's work, because a cloud
+            // callback raised during that work can itself trigger a removal and would deadlock on it.
+            async Task WaitForPendingCloudConnectionRemoval()
             {
                 using (await this.cloudConnectionRemovalLock.LockAsync())
                 {
@@ -757,19 +766,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             bool CloudConnectionRetryIntervalElapsed()
             {
-                if (!this.hasCloudConnectionCreateCompletedTimestamp)
+                if (!this.cloudConnectionCreateCompletedTime.HasValue)
                 {
                     return true;
                 }
 
-                long elapsedTimestamp = this.getTimestamp() - this.cloudConnectionCreateCompletedTimestamp;
-                return elapsedTimestamp < 0
-                    || elapsedTimestamp >= this.cloudConnectionRetryInterval.TotalSeconds * Stopwatch.Frequency;
+                TimeSpan elapsed = this.getMonotonicTime() - this.cloudConnectionCreateCompletedTime.Value;
+                return elapsed < TimeSpan.Zero || elapsed >= this.cloudConnectionRetryInterval;
             }
 
-            void RecordCloudConnectionAttemptCore(
+            void RecordFailedCloudConnectionAttemptCore(
                 Task<Try<ICloudConnection>> createTask,
-                bool shouldThrottle,
                 long connectionGeneration)
             {
                 if (!this.IsCloudConnectionGenerationValid(connectionGeneration))
@@ -779,9 +786,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
                 Volatile.Write(ref this.cloudConnectionCreateGeneration, connectionGeneration);
                 Volatile.Write(ref this.cloudConnectionCreateTask, createTask);
-                this.cloudConnectionCreateCompletedTimestamp = this.getTimestamp();
-                this.hasCloudConnectionCreateCompletedTimestamp = true;
-                this.shouldThrottleCloudConnectionCreation = shouldThrottle;
+                this.cloudConnectionCreateCompletedTime = this.getMonotonicTime();
+                this.shouldThrottleCloudConnectionCreation = true;
             }
 
             void ResetCloudConnectionRetryStateCore(long connectionGeneration)
@@ -793,8 +799,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
                 Volatile.Write(ref this.cloudConnectionCreateGeneration, connectionGeneration);
                 Volatile.Write(ref this.cloudConnectionCreateTask, null);
-                this.cloudConnectionCreateCompletedTimestamp = 0;
-                this.hasCloudConnectionCreateCompletedTimestamp = false;
+                this.cloudConnectionCreateCompletedTime = null;
                 this.shouldThrottleCloudConnectionCreation = false;
             }
 
@@ -808,7 +813,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     var supersededCloudConnections = new List<ICloudConnection>(1);
                     lock (this.cloudConnectionStateLock)
                     {
-                        Interlocked.Increment(ref this.cloudConnectionGeneration);
+                        this.BeginCloudConnectionRemoval();
                         ICloudConnection activeCloudConnection =
                             Interlocked.Exchange(ref this.cloudConnection, null);
                         if (activeCloudConnection != null)
@@ -900,10 +905,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     {
                         lock (this.cloudConnectionStateLock)
                         {
-                            long stableGeneration = Volatile.Read(ref this.cloudConnectionGeneration) + 1;
+                            long stableGeneration = this.NextStableCloudConnectionGeneration();
                             Volatile.Write(ref this.cloudConnectionCreateGeneration, stableGeneration);
-                            this.cloudConnectionCreateCompletedTimestamp = this.getTimestamp();
-                            this.hasCloudConnectionCreateCompletedTimestamp = throttleReconnect;
+                            this.cloudConnectionCreateCompletedTime = throttleReconnect
+                                ? this.getMonotonicTime()
+                                : (TimeSpan?)null;
                             this.shouldThrottleCloudConnectionCreation = throttleReconnect;
                             Volatile.Write(
                                 ref this.cloudConnectionCreateTask,
@@ -913,14 +919,36 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                                             new EdgeHubConnectionException(
                                                 $"Cloud connection for device {this.Identity.Id} was removed after a cloud failure.")))
                                     : null);
-                            Interlocked.Increment(ref this.cloudConnectionGeneration);
+                            this.CompleteCloudConnectionRemoval();
                         }
                     }
                 }
             }
 
+            static bool IsStableGeneration(long generation) => (generation & RemovalInProgressBit) == 0;
+
+            // Cancelling first is what makes the close final: an in-flight token update would otherwise
+            // hand back a live client for a connection the caller has already discarded.
+            static async Task CancelTokenUpdateAndCloseAsync(ICloudConnection cloudConnection)
+            {
+                if (cloudConnection is IClientTokenCloudConnection clientTokenCloudConnection)
+                {
+                    clientTokenCloudConnection.CancelTokenUpdate();
+                }
+
+                await cloudConnection.CloseAsync();
+            }
+
+            void BeginCloudConnectionRemoval() => Interlocked.Increment(ref this.cloudConnectionGeneration);
+
+            void CompleteCloudConnectionRemoval() => Interlocked.Increment(ref this.cloudConnectionGeneration);
+
+            // Only valid while a removal is in progress: the generation is odd, so the next increment
+            // restores the stable generation that post-removal connection attempts will run under.
+            long NextStableCloudConnectionGeneration() => Volatile.Read(ref this.cloudConnectionGeneration) + 1;
+
             bool IsCloudConnectionGenerationValid(long connectionGeneration) =>
-                (connectionGeneration & 1) == 0
+                IsStableGeneration(connectionGeneration)
                 && connectionGeneration == Volatile.Read(ref this.cloudConnectionGeneration);
 
             async Task<Try<ICloudConnection>> DiscardInvalidatedCloudConnection(
@@ -936,12 +964,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                         ref this.preservedCloudConnection,
                         null,
                         cloudConnection.Value);
-                    if (cloudConnection.Value is IClientTokenCloudConnection clientTokenCloudConnection)
-                    {
-                        clientTokenCloudConnection.CancelTokenUpdate();
-                    }
-
-                    await cloudConnection.Value.CloseAsync();
+                    await CancelTokenUpdateAndCloseAsync(cloudConnection.Value);
                 }
 
                 return Try<ICloudConnection>.Failure(

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/cloud/IClientTokenCloudConnection.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/cloud/IClientTokenCloudConnection.cs
@@ -6,6 +6,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Cloud
 
     public interface IClientTokenCloudConnection : ICloudConnection
     {
+        bool HasPendingTokenUpdate { get; }
+
+        void CancelTokenUpdate();
+
         Task<ICloudProxy> UpdateTokenAsync(ITokenCredentials tokenCredentials);
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
@@ -208,6 +208,104 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
         [Fact]
         [Unit]
+        public async Task CanceledConnectionRejectsFutureTokenRequests()
+        {
+            string iothubHostName = "test.azure-devices.net";
+            string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(3));
+            var credentials = new TokenCredentials(
+                new DeviceIdentity(iothubHostName, "device1"),
+                token,
+                string.Empty,
+                Option.None<string>(),
+                Option.None<string>(),
+                false);
+            ITokenProvider tokenProvider = null;
+            IClientProvider clientProvider =
+                GetMockDeviceClientProviderWithToken((_, provider, _, _) => tokenProvider = provider);
+            var transportSettings =
+                new ITransportSettings[] { new AmqpTransportSettings(TransportType.Amqp_Tcp_Only) };
+            var messageConverterProvider = new MessageConverterProvider(
+                new Dictionary<Type, IMessageConverter>
+                {
+                    [typeof(TwinCollection)] = Mock.Of<IMessageConverter>()
+                });
+            ClientTokenCloudConnection cloudConnection = await ClientTokenCloudConnection.Create(
+                credentials,
+                (_, __) => { },
+                transportSettings,
+                messageConverterProvider,
+                clientProvider,
+                Mock.Of<ICloudListener>(),
+                TimeSpan.FromMinutes(60),
+                true,
+                TimeSpan.FromSeconds(20),
+                TimeSpan.FromSeconds(50),
+                DummyProductInfo,
+                Option.None<string>());
+
+            cloudConnection.CancelTokenUpdate();
+
+            Assert.NotNull(tokenProvider);
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => tokenProvider.GetTokenAsync(Option.None<TimeSpan>()));
+            Assert.False(cloudConnection.HasPendingTokenUpdate);
+        }
+
+        [Fact]
+        [Unit]
+        public async Task CancellationDuringRetrySuppressesTokenStatusCallback()
+        {
+            string iothubHostName = "test.azure-devices.net";
+            string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(3));
+            var credentials = new TokenCredentials(
+                new DeviceIdentity(iothubHostName, "device1"),
+                token,
+                string.Empty,
+                Option.None<string>(),
+                Option.None<string>(),
+                false);
+            ITokenProvider tokenProvider = null;
+            IClientProvider clientProvider =
+                GetMockDeviceClientProviderWithToken((_, provider, _, _) => tokenProvider = provider);
+            var transportSettings =
+                new ITransportSettings[] { new AmqpTransportSettings(TransportType.Amqp_Tcp_Only) };
+            var receivedStatuses = new List<CloudConnectionStatus>();
+            var messageConverterProvider = new MessageConverterProvider(
+                new Dictionary<Type, IMessageConverter>
+                {
+                    [typeof(TwinCollection)] = Mock.Of<IMessageConverter>()
+                });
+            ClientTokenCloudConnection cloudConnection = await ClientTokenCloudConnection.Create(
+                credentials,
+                (_, status) => receivedStatuses.Add(status),
+                transportSettings,
+                messageConverterProvider,
+                clientProvider,
+                Mock.Of<ICloudListener>(),
+                TimeSpan.FromMinutes(60),
+                true,
+                TimeSpan.FromSeconds(20),
+                TimeSpan.FromSeconds(50),
+                DummyProductInfo,
+                Option.None<string>());
+            Assert.NotNull(tokenProvider);
+
+            Task<string> getTokenTask = tokenProvider.GetTokenAsync(Option.None<TimeSpan>());
+            Assert.Single(receivedStatuses);
+            await cloudConnection.UpdateTokenAsync(credentials);
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            Assert.True(cloudConnection.HasPendingTokenUpdate);
+
+            cloudConnection.CancelTokenUpdate();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => getTokenTask);
+            await Task.Delay(TimeSpan.FromSeconds(20));
+            Assert.Single(receivedStatuses);
+            Assert.False(cloudConnection.HasPendingTokenUpdate);
+        }
+
+        [Fact]
+        [Unit]
         public async Task RefreshTokenWithRetryTest()
         {
             string iothubHostName = "test.azure-devices.net";

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
@@ -270,6 +270,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var transportSettings =
                 new ITransportSettings[] { new AmqpTransportSettings(TransportType.Amqp_Tcp_Only) };
             var receivedStatuses = new List<CloudConnectionStatus>();
+            var retryDelayEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseRetryDelay = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var messageConverterProvider = new MessageConverterProvider(
                 new Dictionary<Type, IMessageConverter>
                 {
@@ -287,19 +289,24 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 TimeSpan.FromSeconds(20),
                 TimeSpan.FromSeconds(50),
                 DummyProductInfo,
-                Option.None<string>());
+                Option.None<string>(),
+                () =>
+                {
+                    retryDelayEntered.TrySetResult(true);
+                    return releaseRetryDelay.Task;
+                });
             Assert.NotNull(tokenProvider);
 
             Task<string> getTokenTask = tokenProvider.GetTokenAsync(Option.None<TimeSpan>());
             Assert.Single(receivedStatuses);
             await cloudConnection.UpdateTokenAsync(credentials);
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await retryDelayEntered.Task;
             Assert.True(cloudConnection.HasPendingTokenUpdate);
 
             cloudConnection.CancelTokenUpdate();
+            releaseRetryDelay.TrySetResult(true);
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => getTokenTask);
-            await Task.Delay(TimeSpan.FromSeconds(20));
             Assert.Single(receivedStatuses);
             Assert.False(cloudConnection.HasPendingTokenUpdate);
         }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
@@ -574,25 +575,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
         [Fact]
         [Unit]
-        public async Task GetCloudConnectionReusesRecentInactiveConnectionCreation()
+        public async Task GetCloudConnectionThrottlesRepeatedFailedCreation()
         {
             const string DeviceId = "device1";
             const int OperationCount = 200;
             TimeSpan retryInterval = TimeSpan.FromSeconds(5);
-            DateTime now = new DateTime(2026, 8, 6, 0, 0, 0, DateTimeKind.Utc);
-            var systemTime = new Mock<ISystemTime>();
-            systemTime.SetupGet(t => t.UtcNow).Returns(() => now);
-
-            var cloudProxy = Mock.Of<ICloudProxy>(p => !p.IsActive);
-            Mock.Get(cloudProxy)
-                .Setup(p => p.SendMessageAsync(It.IsAny<IMessage>()))
-                .ThrowsAsync(new ObjectDisposedException("cloud proxy"));
-            var cloudConnection = Mock.Of<ICloudConnection>(
-                c => !c.IsActive && c.CloudProxy == Option.Some(cloudProxy));
+            long timestamp = 0;
             var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
             cloudConnectionProvider
                 .Setup(c => c.Connect(It.Is<IIdentity>(i => i.Id == DeviceId), It.IsAny<Action<string, CloudConnectionStatus>>()))
-                .ReturnsAsync(Try.Success(cloudConnection));
+                .ReturnsAsync(Try<ICloudConnection>.Failure(new TimeoutException()));
 
             var connectionManager = new ConnectionManager(
                 cloudConnectionProvider.Object,
@@ -602,16 +594,92 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 101,
                 true,
                 retryInterval,
-                systemTime.Object);
+                () => timestamp);
 
-            Option<ICloudProxy> initialCloudProxy = await connectionManager.GetCloudConnection(DeviceId);
-            Assert.True(initialCloudProxy.HasValue);
+            Task<Option<ICloudProxy>>[] operations = Enumerable.Range(0, OperationCount)
+                .Select(_ => connectionManager.GetCloudConnection(DeviceId))
+                .ToArray();
+            Option<ICloudProxy>[] results = await Task.WhenAll(operations);
+
+            Assert.All(results, result => Assert.False(result.HasValue));
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Once);
+
+            timestamp += (long)(retryInterval.TotalSeconds * Stopwatch.Frequency);
+            Option<ICloudProxy> resultAfterRetryInterval = await connectionManager.GetCloudConnection(DeviceId);
+
+            Assert.False(resultAfterRetryInterval.HasValue);
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Exactly(2));
+        }
+
+        [Fact]
+        [Unit]
+        public async Task GetCloudConnectionThrottlesImmediatelyInactiveReplacements()
+        {
+            const string DeviceId = "device1";
+            const int OperationCount = 200;
+            TimeSpan retryInterval = TimeSpan.FromSeconds(5);
+            long timestamp = 0;
+            bool initialConnectionActive = true;
+
+            var initialCloudProxy = new Mock<ICloudProxy>();
+            initialCloudProxy.SetupGet(p => p.IsActive).Returns(() => initialConnectionActive);
+            var initialCloudConnection = new Mock<ICloudConnection>();
+            initialCloudConnection.SetupGet(c => c.IsActive).Returns(() => initialConnectionActive);
+            initialCloudConnection.SetupGet(c => c.CloudProxy).Returns(
+                () => initialConnectionActive
+                    ? Option.Some(initialCloudProxy.Object)
+                    : Option.None<ICloudProxy>());
+
+            Try<ICloudConnection> CreateFailingReplacement()
+            {
+                bool isActive = true;
+                var cloudProxy = new Mock<ICloudProxy>();
+                cloudProxy.SetupGet(p => p.IsActive).Returns(() => isActive);
+                cloudProxy
+                    .Setup(p => p.SendMessageAsync(It.IsAny<IMessage>()))
+                    .Callback(() => isActive = false)
+                    .ThrowsAsync(new ObjectDisposedException("cloud proxy"));
+                var cloudConnection = new Mock<ICloudConnection>();
+                cloudConnection.SetupGet(c => c.IsActive).Returns(() => isActive);
+                cloudConnection.SetupGet(c => c.CloudProxy).Returns(
+                    () => isActive
+                        ? Option.Some(cloudProxy.Object)
+                        : Option.None<ICloudProxy>());
+                return Try.Success(cloudConnection.Object);
+            }
+
+            int connectionCount = 0;
+            var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
+            cloudConnectionProvider
+                .Setup(c => c.Connect(It.Is<IIdentity>(i => i.Id == DeviceId), It.IsAny<Action<string, CloudConnectionStatus>>()))
+                .ReturnsAsync(
+                    () => ++connectionCount == 1
+                        ? Try.Success(initialCloudConnection.Object)
+                        : CreateFailingReplacement());
+
+            var connectionManager = new ConnectionManager(
+                cloudConnectionProvider.Object,
+                Mock.Of<ICredentialsCache>(),
+                GetIdentityProvider(),
+                Mock.Of<IDeviceConnectivityManager>(),
+                101,
+                true,
+                retryInterval,
+                () => timestamp);
+
+            Option<ICloudProxy> cloudProxy = await connectionManager.GetCloudConnection(DeviceId);
+            Assert.True(cloudProxy.HasValue);
+            initialConnectionActive = false;
 
             IMessage message = Mock.Of<IMessage>();
-            Task<ObjectDisposedException>[] operations = Enumerable.Range(0, OperationCount)
+            Task<EdgeHubIOException>[] operations = Enumerable.Range(0, OperationCount)
                 .Select(
-                    _ => Assert.ThrowsAsync<ObjectDisposedException>(
-                        () => initialCloudProxy.OrDefault().SendMessageAsync(message)))
+                    _ => Assert.ThrowsAsync<EdgeHubIOException>(
+                        () => cloudProxy.OrDefault().SendMessageAsync(message)))
                 .ToArray();
             await Task.WhenAll(operations);
 
@@ -619,13 +687,286 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
                 Times.Exactly(2));
 
-            now += retryInterval;
-            await Assert.ThrowsAsync<ObjectDisposedException>(
-                () => initialCloudProxy.OrDefault().SendMessageAsync(message));
+            timestamp += (long)(retryInterval.TotalSeconds * Stopwatch.Frequency);
+            await Assert.ThrowsAsync<EdgeHubIOException>(
+                () => cloudProxy.OrDefault().SendMessageAsync(message));
 
             cloudConnectionProvider.Verify(
                 c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
                 Times.Exactly(3));
+        }
+
+        [Fact]
+        [Unit]
+        public async Task RemoveDeviceConnectionInvalidatesInFlightCloudConnection()
+        {
+            const string DeviceId = "device1";
+            bool isActive = true;
+            var cloudProxy = Mock.Of<ICloudProxy>(p => p.IsActive);
+            var cloudConnection = new Mock<ICloudConnection>();
+            cloudConnection.SetupGet(c => c.IsActive).Returns(() => isActive);
+            cloudConnection.SetupGet(c => c.CloudProxy).Returns(() => Option.Some(cloudProxy));
+            cloudConnection
+                .Setup(c => c.CloseAsync())
+                .Callback(() => isActive = false)
+                .ReturnsAsync(true);
+
+            var connectionSource = new TaskCompletionSource<Try<ICloudConnection>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
+            cloudConnectionProvider
+                .Setup(c => c.Connect(It.Is<IIdentity>(i => i.Id == DeviceId), It.IsAny<Action<string, CloudConnectionStatus>>()))
+                .Returns(connectionSource.Task);
+            var connectionManager = new ConnectionManager(
+                cloudConnectionProvider.Object,
+                Mock.Of<ICredentialsCache>(),
+                GetIdentityProvider(),
+                Mock.Of<IDeviceConnectivityManager>());
+
+            Task<Option<ICloudProxy>> getCloudConnection = connectionManager.GetCloudConnection(DeviceId);
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Once);
+
+            await connectionManager.RemoveDeviceConnection(DeviceId);
+            connectionSource.SetResult(Try.Success(cloudConnection.Object));
+            Option<ICloudProxy> result = await getCloudConnection;
+
+            Assert.False(result.HasValue);
+            Assert.False(isActive);
+            cloudConnection.Verify(c => c.CloseAsync(), Times.Once);
+        }
+
+        [Fact]
+        [Unit]
+        public async Task CreateCloudConnectionWaitsForRemovalToComplete()
+        {
+            const string DeviceId = "device1";
+            var identity = new DeviceIdentity(IotHubHostName, DeviceId);
+            var credentials = new TokenCredentials(
+                identity,
+                DummyToken,
+                DummyProductInfo,
+                Option.None<string>(),
+                Option.None<string>(),
+                false);
+            bool firstConnectionActive = true;
+            var firstCloudProxy = Mock.Of<ICloudProxy>(p => p.IsActive);
+            var closeStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var closeConnection = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstCloudConnection = new Mock<ICloudConnection>();
+            firstCloudConnection.SetupGet(c => c.IsActive).Returns(() => firstConnectionActive);
+            firstCloudConnection.SetupGet(c => c.CloudProxy).Returns(() => Option.Some(firstCloudProxy));
+            firstCloudConnection
+                .Setup(c => c.CloseAsync())
+                .Callback(() => closeStarted.SetResult(true))
+                .Returns(closeConnection.Task);
+
+            var secondCloudProxy = Mock.Of<ICloudProxy>(p => p.IsActive);
+            var secondCloudConnection = Mock.Of<ICloudConnection>(
+                c => c.IsActive && c.CloudProxy == Option.Some(secondCloudProxy));
+            var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
+            cloudConnectionProvider
+                .SetupSequence(c => c.Connect(It.IsAny<IClientCredentials>(), It.IsAny<Action<string, CloudConnectionStatus>>()))
+                .ReturnsAsync(Try.Success(firstCloudConnection.Object))
+                .ReturnsAsync(Try.Success(secondCloudConnection));
+            var connectionManager = new ConnectionManager(
+                cloudConnectionProvider.Object,
+                Mock.Of<ICredentialsCache>(),
+                GetIdentityProvider(),
+                Mock.Of<IDeviceConnectivityManager>());
+
+            Try<ICloudProxy> firstResult = await connectionManager.CreateCloudConnectionAsync(credentials);
+            Assert.True(firstResult.Success);
+
+            Task removeConnection = connectionManager.RemoveDeviceConnection(DeviceId);
+            await closeStarted.Task;
+            Option<ICloudProxy> resultDuringRemoval = await connectionManager.GetCloudConnection(DeviceId);
+            Task<Try<ICloudProxy>> createConnection = connectionManager.CreateCloudConnectionAsync(credentials);
+
+            Assert.False(resultDuringRemoval.HasValue);
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IClientCredentials>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Once);
+
+            firstConnectionActive = false;
+            closeConnection.SetResult(true);
+            await removeConnection;
+            Try<ICloudProxy> secondResult = await createConnection;
+
+            Assert.True(secondResult.Success);
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IClientCredentials>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Exactly(2));
+        }
+
+        [Fact]
+        [Unit]
+        public async Task TokenExpiredRemovalPreservesConnectionOnlyForTokenUpdate()
+        {
+            const string DeviceId = "device1";
+            const int OperationCount = 200;
+            TimeSpan retryInterval = TimeSpan.FromSeconds(5);
+            long timestamp = 0;
+            Action<string, CloudConnectionStatus> statusChangedHandler = null;
+            var connectionRemoved = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var cloudProxy = Mock.Of<ICloudProxy>(p => p.IsActive);
+            var updatedCloudProxy = Mock.Of<ICloudProxy>(p => p.IsActive);
+            bool tokenUpdated = false;
+            var cloudConnection = new Mock<IClientTokenCloudConnection>();
+            cloudConnection.SetupGet(c => c.IsActive).Returns(true);
+            cloudConnection
+                .SetupGet(c => c.CloudProxy)
+                .Returns(() => Option.Some(tokenUpdated ? updatedCloudProxy : cloudProxy));
+            cloudConnection
+                .SetupGet(c => c.HasPendingTokenUpdate)
+                .Callback(() => connectionRemoved.TrySetResult(true))
+                .Returns(true);
+            cloudConnection
+                .Setup(c => c.CloseAsync())
+                .ReturnsAsync(true);
+            cloudConnection
+                .Setup(c => c.UpdateTokenAsync(It.IsAny<ITokenCredentials>()))
+                .Callback(() => tokenUpdated = true)
+                .ReturnsAsync(updatedCloudProxy);
+
+            int connectionCount = 0;
+            var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
+            cloudConnectionProvider
+                .Setup(c => c.Connect(It.Is<IIdentity>(i => i.Id == DeviceId), It.IsAny<Action<string, CloudConnectionStatus>>()))
+                .Callback<IIdentity, Action<string, CloudConnectionStatus>>((_, handler) => statusChangedHandler = handler)
+                .ReturnsAsync(
+                    () => ++connectionCount == 1
+                        ? Try.Success(cloudConnection.Object as ICloudConnection)
+                        : Try<ICloudConnection>.Failure(new TimeoutException()));
+
+            var connectionManager = new ConnectionManager(
+                cloudConnectionProvider.Object,
+                Mock.Of<ICredentialsCache>(),
+                GetIdentityProvider(),
+                Mock.Of<IDeviceConnectivityManager>(),
+                101,
+                true,
+                retryInterval,
+                () => timestamp);
+
+            Option<ICloudProxy> initialCloudProxy = await connectionManager.GetCloudConnection(DeviceId);
+            Assert.True(initialCloudProxy.HasValue);
+            Assert.NotNull(statusChangedHandler);
+
+            statusChangedHandler(DeviceId, CloudConnectionStatus.DisconnectedTokenExpired);
+            await connectionRemoved.Task;
+
+            Task<Option<ICloudProxy>>[] operations = Enumerable.Range(0, OperationCount)
+                .Select(_ => connectionManager.GetCloudConnection(DeviceId))
+                .ToArray();
+            Option<ICloudProxy>[] results = await Task.WhenAll(operations);
+
+            Assert.All(results, result => Assert.False(result.HasValue));
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Once);
+            cloudConnection.Verify(c => c.CloseAsync(), Times.Never);
+
+            var updatedCredentials = new TokenCredentials(
+                new DeviceIdentity(IotHubHostName, DeviceId),
+                DummyToken,
+                DummyProductInfo,
+                Option.None<string>(),
+                Option.None<string>(),
+                true);
+            Try<ICloudProxy> updatedConnection =
+                await connectionManager.CreateCloudConnectionAsync(updatedCredentials);
+
+            Assert.True(updatedConnection.Success);
+            Assert.Same(updatedCloudProxy, ((RetryingCloudProxy)updatedConnection.Value).InnerCloudProxy);
+            Option<ICloudProxy> activeConnection = await connectionManager.GetCloudConnection(DeviceId);
+            Assert.True(activeConnection.HasValue);
+            Assert.Same(updatedCloudProxy, ((RetryingCloudProxy)activeConnection.OrDefault()).InnerCloudProxy);
+            cloudConnection.Verify(c => c.UpdateTokenAsync(updatedCredentials), Times.Once);
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        [Unit]
+        public async Task TokenExpiredRemovalCancelsConnectionWithoutPendingUpdate()
+        {
+            const string DeviceId = "device1";
+            bool tokenUpdateCanceled = false;
+            Action<string, CloudConnectionStatus> statusChangedHandler = null;
+            var connectionClosed = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var cloudProxy = Mock.Of<ICloudProxy>(p => p.IsActive);
+            var replacementCloudProxy = Mock.Of<ICloudProxy>(p => p.IsActive);
+            var replacementCloudConnection = Mock.Of<ICloudConnection>(
+                c => c.IsActive && c.CloudProxy == Option.Some(replacementCloudProxy));
+            var cloudConnection = new Mock<IClientTokenCloudConnection>();
+            cloudConnection.SetupGet(c => c.IsActive).Returns(true);
+            cloudConnection.SetupGet(c => c.CloudProxy).Returns(Option.Some(cloudProxy));
+            cloudConnection.SetupGet(c => c.HasPendingTokenUpdate).Returns(false);
+            cloudConnection
+                .Setup(c => c.CancelTokenUpdate())
+                .Callback(() => tokenUpdateCanceled = true);
+            cloudConnection
+                .Setup(c => c.CloseAsync())
+                .Callback(
+                    () =>
+                    {
+                        Assert.True(tokenUpdateCanceled);
+                        connectionClosed.TrySetResult(true);
+                    })
+                .ReturnsAsync(true);
+            var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
+            cloudConnectionProvider
+                .Setup(c => c.Connect(It.Is<IIdentity>(i => i.Id == DeviceId), It.IsAny<Action<string, CloudConnectionStatus>>()))
+                .Callback<IIdentity, Action<string, CloudConnectionStatus>>((_, handler) => statusChangedHandler = handler)
+                .ReturnsAsync(Try.Success(cloudConnection.Object as ICloudConnection));
+            cloudConnectionProvider
+                .Setup(c => c.Connect(It.Is<IClientCredentials>(credentials => credentials.Identity.Id == DeviceId), It.IsAny<Action<string, CloudConnectionStatus>>()))
+                .ReturnsAsync(Try.Success(replacementCloudConnection));
+            var connectionManager = new ConnectionManager(
+                cloudConnectionProvider.Object,
+                Mock.Of<ICredentialsCache>(),
+                GetIdentityProvider(),
+                Mock.Of<IDeviceConnectivityManager>());
+
+            Option<ICloudProxy> initialConnection = await connectionManager.GetCloudConnection(DeviceId);
+            Assert.True(initialConnection.HasValue);
+            Assert.NotNull(statusChangedHandler);
+
+            statusChangedHandler(DeviceId, CloudConnectionStatus.DisconnectedTokenExpired);
+            await connectionClosed.Task;
+
+            cloudConnection.Verify(c => c.CancelTokenUpdate(), Times.Once);
+            cloudConnection.Verify(c => c.CloseAsync(), Times.Once);
+            Option<ICloudProxy> removedConnection = await connectionManager.GetCloudConnection(DeviceId);
+            Assert.False(removedConnection.HasValue);
+
+            var replacementCredentials = new TokenCredentials(
+                new DeviceIdentity(IotHubHostName, DeviceId),
+                DummyToken,
+                DummyProductInfo,
+                Option.None<string>(),
+                Option.None<string>(),
+                true);
+            Try<ICloudProxy> replacementConnection =
+                await connectionManager.CreateCloudConnectionAsync(replacementCredentials);
+
+            Assert.True(replacementConnection.Success);
+            Assert.Same(
+                replacementCloudProxy,
+                ((RetryingCloudProxy)replacementConnection.Value).InnerCloudProxy);
+            cloudConnection.Verify(
+                c => c.UpdateTokenAsync(It.IsAny<ITokenCredentials>()),
+                Times.Never);
+            cloudConnectionProvider.Verify(
+                c => c.Connect(replacementCredentials, It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Once);
         }
 
         [Fact]

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -574,6 +574,62 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
         [Fact]
         [Unit]
+        public async Task GetCloudConnectionReusesRecentInactiveConnectionCreation()
+        {
+            const string DeviceId = "device1";
+            const int OperationCount = 200;
+            TimeSpan retryInterval = TimeSpan.FromSeconds(5);
+            DateTime now = new DateTime(2026, 8, 6, 0, 0, 0, DateTimeKind.Utc);
+            var systemTime = new Mock<ISystemTime>();
+            systemTime.SetupGet(t => t.UtcNow).Returns(() => now);
+
+            var cloudProxy = Mock.Of<ICloudProxy>(p => !p.IsActive);
+            Mock.Get(cloudProxy)
+                .Setup(p => p.SendMessageAsync(It.IsAny<IMessage>()))
+                .ThrowsAsync(new ObjectDisposedException("cloud proxy"));
+            var cloudConnection = Mock.Of<ICloudConnection>(
+                c => !c.IsActive && c.CloudProxy == Option.Some(cloudProxy));
+            var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
+            cloudConnectionProvider
+                .Setup(c => c.Connect(It.Is<IIdentity>(i => i.Id == DeviceId), It.IsAny<Action<string, CloudConnectionStatus>>()))
+                .ReturnsAsync(Try.Success(cloudConnection));
+
+            var connectionManager = new ConnectionManager(
+                cloudConnectionProvider.Object,
+                Mock.Of<ICredentialsCache>(),
+                GetIdentityProvider(),
+                Mock.Of<IDeviceConnectivityManager>(),
+                101,
+                true,
+                retryInterval,
+                systemTime.Object);
+
+            Option<ICloudProxy> initialCloudProxy = await connectionManager.GetCloudConnection(DeviceId);
+            Assert.True(initialCloudProxy.HasValue);
+
+            IMessage message = Mock.Of<IMessage>();
+            Task<ObjectDisposedException>[] operations = Enumerable.Range(0, OperationCount)
+                .Select(
+                    _ => Assert.ThrowsAsync<ObjectDisposedException>(
+                        () => initialCloudProxy.OrDefault().SendMessageAsync(message)))
+                .ToArray();
+            await Task.WhenAll(operations);
+
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Exactly(2));
+
+            now += retryInterval;
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => initialCloudProxy.OrDefault().SendMessageAsync(message));
+
+            cloudConnectionProvider.Verify(
+                c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
+                Times.Exactly(3));
+        }
+
+        [Fact]
+        [Unit]
         public async Task CreateCloudProxyTest()
         {
             string edgeDeviceId = "edgeDevice";

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -3,7 +3,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
@@ -580,7 +579,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             const string DeviceId = "device1";
             const int OperationCount = 200;
             TimeSpan retryInterval = TimeSpan.FromSeconds(5);
-            long timestamp = 0;
+            TimeSpan monotonicTime = TimeSpan.Zero;
             var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
             cloudConnectionProvider
                 .Setup(c => c.Connect(It.Is<IIdentity>(i => i.Id == DeviceId), It.IsAny<Action<string, CloudConnectionStatus>>()))
@@ -591,10 +590,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 Mock.Of<ICredentialsCache>(),
                 GetIdentityProvider(),
                 Mock.Of<IDeviceConnectivityManager>(),
-                101,
-                true,
+                maxClients: 101,
+                closeCloudConnectionOnDeviceDisconnect: true,
                 retryInterval,
-                () => timestamp);
+                () => monotonicTime);
 
             Task<Option<ICloudProxy>>[] operations = Enumerable.Range(0, OperationCount)
                 .Select(_ => connectionManager.GetCloudConnection(DeviceId))
@@ -606,7 +605,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
                 Times.Once);
 
-            timestamp += (long)(retryInterval.TotalSeconds * Stopwatch.Frequency);
+            monotonicTime += retryInterval;
             Option<ICloudProxy> resultAfterRetryInterval = await connectionManager.GetCloudConnection(DeviceId);
 
             Assert.False(resultAfterRetryInterval.HasValue);
@@ -622,7 +621,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             const string DeviceId = "device1";
             const int OperationCount = 200;
             TimeSpan retryInterval = TimeSpan.FromSeconds(5);
-            long timestamp = 0;
+            TimeSpan monotonicTime = TimeSpan.Zero;
             bool initialConnectionActive = true;
 
             var initialCloudProxy = new Mock<ICloudProxy>();
@@ -666,10 +665,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 Mock.Of<ICredentialsCache>(),
                 GetIdentityProvider(),
                 Mock.Of<IDeviceConnectivityManager>(),
-                101,
-                true,
+                maxClients: 101,
+                closeCloudConnectionOnDeviceDisconnect: true,
                 retryInterval,
-                () => timestamp);
+                () => monotonicTime);
 
             Option<ICloudProxy> cloudProxy = await connectionManager.GetCloudConnection(DeviceId);
             Assert.True(cloudProxy.HasValue);
@@ -687,7 +686,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 c => c.Connect(It.IsAny<IIdentity>(), It.IsAny<Action<string, CloudConnectionStatus>>()),
                 Times.Exactly(2));
 
-            timestamp += (long)(retryInterval.TotalSeconds * Stopwatch.Frequency);
+            monotonicTime += retryInterval;
             await Assert.ThrowsAsync<EdgeHubIOException>(
                 () => cloudProxy.OrDefault().SendMessageAsync(message));
 
@@ -809,7 +808,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             const string DeviceId = "device1";
             const int OperationCount = 200;
             TimeSpan retryInterval = TimeSpan.FromSeconds(5);
-            long timestamp = 0;
+            TimeSpan monotonicTime = TimeSpan.Zero;
             Action<string, CloudConnectionStatus> statusChangedHandler = null;
             var connectionRemoved = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
@@ -848,10 +847,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 Mock.Of<ICredentialsCache>(),
                 GetIdentityProvider(),
                 Mock.Of<IDeviceConnectivityManager>(),
-                101,
-                true,
+                maxClients: 101,
+                closeCloudConnectionOnDeviceDisconnect: true,
                 retryInterval,
-                () => timestamp);
+                () => monotonicTime);
 
             Option<ICloudProxy> initialCloudProxy = await connectionManager.GetCloudConnection(DeviceId);
             Assert.True(initialCloudProxy.HasValue);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Net;
     using System.Threading;
@@ -374,7 +375,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 101,
                 true,
                 TimeSpan.Zero,
-                SystemTime.Instance);
+                Stopwatch.GetTimestamp);
 
         static async Task RunSendMessages(ICloudProxy cloudProxy, IEnumerable<IMessage> messages, int batchSize = 1)
         {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
@@ -93,7 +93,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(connectionProvider, credentialsCache.Object, identityProvider.Object, deviceConnectivityManager);
+            var connectionManager = CreateConnectionManagerWithoutCloudConnectionRetryDelay(
+                connectionProvider,
+                credentialsCache.Object,
+                identityProvider.Object,
+                deviceConnectivityManager);
             var messagesToSend = new List<IMessage>();
             for (int i = 0; i < 10; i++)
             {
@@ -200,7 +204,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(connectionProvider, credentialsCache.Object, identityProvider.Object, deviceConnectivityManager);
+            var connectionManager = CreateConnectionManagerWithoutCloudConnectionRetryDelay(
+                connectionProvider,
+                credentialsCache.Object,
+                identityProvider.Object,
+                deviceConnectivityManager);
 
             // Act
             Option<ICloudProxy> cloudProxyOption = await connectionManager.GetCloudConnection(Id);
@@ -291,7 +299,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(connectionProvider, credentialsCache.Object, identityProvider.Object, deviceConnectivityManager);
+            var connectionManager = CreateConnectionManagerWithoutCloudConnectionRetryDelay(
+                connectionProvider,
+                credentialsCache.Object,
+                identityProvider.Object,
+                deviceConnectivityManager);
 
             async Task<ICloudProxy> GetCloudProxy(IConnectionManager cm)
             {
@@ -348,6 +360,21 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Assert.Equal(expectedMessageIds.Count, receivedMessageIds.Count);
             Assert.Equal(expectedMessageIds, receivedMessageIds);
         }
+
+        static ConnectionManager CreateConnectionManagerWithoutCloudConnectionRetryDelay(
+            ICloudConnectionProvider connectionProvider,
+            ICredentialsCache credentialsCache,
+            IIdentityProvider identityProvider,
+            IDeviceConnectivityManager deviceConnectivityManager) =>
+            new ConnectionManager(
+                connectionProvider,
+                credentialsCache,
+                identityProvider,
+                deviceConnectivityManager,
+                101,
+                true,
+                TimeSpan.Zero,
+                SystemTime.Instance);
 
         static async Task RunSendMessages(ICloudProxy cloudProxy, IEnumerable<IMessage> messages, int batchSize = 1)
         {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
@@ -366,16 +366,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             ICloudConnectionProvider connectionProvider,
             ICredentialsCache credentialsCache,
             IIdentityProvider identityProvider,
-            IDeviceConnectivityManager deviceConnectivityManager) =>
-            new ConnectionManager(
+            IDeviceConnectivityManager deviceConnectivityManager)
+        {
+            var monotonicClock = Stopwatch.StartNew();
+            return new ConnectionManager(
                 connectionProvider,
                 credentialsCache,
                 identityProvider,
                 deviceConnectivityManager,
-                101,
-                true,
+                maxClients: 101,
+                closeCloudConnectionOnDeviceDisconnect: true,
                 TimeSpan.Zero,
-                Stopwatch.GetTimestamp);
+                () => monotonicClock.Elapsed);
+        }
 
         static async Task RunSendMessages(ICloudProxy cloudProxy, IEnumerable<IMessage> messages, int batchSize = 1)
         {


### PR DESCRIPTION
## Summary
- Five-second per-device cooldown for failed or rapidly inactive cloud proxy creation; initial creation and first replacement immediate.
- Typed monotonic retry timing using an elapsed `TimeSpan`, avoiding wall-clock and raw tick-unit coupling.
- Active connection state separated from a preserved pending-token handoff so normal lookup cannot return the handoff slot.
- Explicit generation/removal invariants and serialized removal so stale creation/update results are discarded.
- Shared creation task published under the state lock, while caller-supplied asynchronous creation starts only after releasing that lock.
- Atomic `TaskCompletionSource` token waiter lifecycle, stale callback suppression, and cancel-before-close cleanup for discarded connections.
- Deterministic token-retry tests through a narrow injected delay seam instead of fixed sleeps.

Fixes #7535

## Testing
- `ConnectionManagerTest` and `RetryingCloudProxyTest`: **34 passed**
- `ClientTokenCloudConnectionTest`: **9 passed**
- .NET 10 `CheckInBuild` / StyleCop: **passed**
- Six-model principal-engineer panel: **satisfied**