### PR TITLE
Handle new OCI layout for attestation manifests

### DIFF
--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -56,5 +56,6 @@ steps:
         --registry '$(registry.address)' \
         --repo-src 'microsoft/${{ parameters.name }}' \
         --repo-dst 'deleteme/${{ parameters.name }}' \
-        --tag '${{ parameters.version }}'
+        --tag '${{ parameters.version }}' \
+        --tags-add '[]'
     displayName: REMOVE ME - copy ${{ parameters.displayName }} to another repo

--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -58,4 +58,5 @@ steps:
         --repo-dst 'deleteme/${{ parameters.name }}' \
         --tag '${{ parameters.version }}' \
         --tags-add '[]'
+    condition: and(succeeded(), ne(variables['System.JobName'], 'BuildImageFunctionsSample'))
     displayName: REMOVE ME - copy ${{ parameters.displayName }} to another repo

--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -50,13 +50,3 @@ steps:
         --registry '$(registry.address)' \
         --version '${{ parameters.version }}'
     displayName: Build Image - ${{ parameters.displayName }}
-
-  - script: |
-      scripts/linux/copy-multi-platform-image.sh \
-        --registry '$(registry.address)' \
-        --repo-src 'microsoft/${{ parameters.name }}' \
-        --repo-dst 'deleteme/${{ parameters.name }}' \
-        --tag '${{ parameters.version }}' \
-        --tags-add '[]'
-    condition: and(succeeded(), ne(variables['System.JobName'], 'BuildImageFunctionsSample'))
-    displayName: REMOVE ME - copy ${{ parameters.displayName }} to another repo

--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -50,3 +50,11 @@ steps:
         --registry '$(registry.address)' \
         --version '${{ parameters.version }}'
     displayName: Build Image - ${{ parameters.displayName }}
+
+  - script: |
+      scripts/linux/copy-multi-platform-image.sh \
+        --registry '$(registry.address)' \
+        --repo-src 'microsoft/${{ parameters.name }}' \
+        --repo-dst 'deleteme/${{ parameters.name }}' \
+        --tag '${{ parameters.version }}'
+    displayName: REMOVE ME - copy ${{ parameters.displayName }} to another repo

--- a/scripts/linux/buildImage.sh
+++ b/scripts/linux/buildImage.sh
@@ -198,10 +198,28 @@ process_args $@
 DOCKERFILE="$APP_BINARIESDIRECTORY/docker/linux/Dockerfile"
 IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_IMAGENAME:$DOCKER_IMAGEVERSION"
 
-echo "Building and pushing image '$IMAGE'"
-
 docker buildx create --use --bootstrap
 trap "docker buildx rm" EXIT
+
+# Dump docker version and config information to help with debugging
+echo "--------------------"
+echo "> docker version"
+docker version
+echo "--------------------"
+echo "> docker buildx version"
+docker buildx version
+echo "--------------------"
+echo "> docker buildx inspect --bootstrap"
+docker buildx inspect --bootstrap
+echo "--------------------"
+echo "> docker info"
+docker info
+echo "--------------------"
+echo "> BUILDX_* and BUILDKIT_* environment variables"
+env | grep -E '^(BUILDX|BUILDKIT)_' | sort
+echo "--------------------"
+
+echo "Building and pushing image '$IMAGE'"
 
 if [[ "$APP" == 'api-proxy-module' ]]; then
     # First, build each platform-specific image from a separate Dockerfile. This will create

--- a/scripts/linux/buildImage.sh
+++ b/scripts/linux/buildImage.sh
@@ -216,7 +216,7 @@ echo "> docker info"
 docker info
 echo "--------------------"
 echo "> BUILDX_* and BUILDKIT_* environment variables"
-env | grep -E '^(BUILDX|BUILDKIT)_' | sort
+env | awk '/^(BUILDX|BUILDKIT)_/' | sort
 echo "--------------------"
 
 echo "Building and pushing image '$IMAGE'"

--- a/scripts/linux/manifest-tools.sh
+++ b/scripts/linux/manifest-tools.sh
@@ -341,7 +341,7 @@ get_manifest_digests() {
 # Outputs
 #   TOKEN           Unchanged if set by caller, otherwise it will contain a valid bearer token
 #
-copy_layers() {
+copy_blobs() {
     # Ensure the manifest has a mediaType we understand
     local media_type=$(echo "$MANIFEST" | jq -r '.mediaType')
     if [[ "$media_type" != 'application/vnd.oci.image.manifest.v1+json' ]] &&
@@ -352,12 +352,14 @@ copy_layers() {
 
     __get_token_with_scope "repository:$REPO_SRC:pull repository:$REPO_DST:pull,push"
 
-    # Parse the layer digests from the manifest
-    local digests=( $(echo "$MANIFEST" | jq -r '.. | objects | select(has("digest")) | .digest') )
+    # Parse the config and layer blob digests from the manifest
+    local digests=(
+        $(echo "$MANIFEST" | jq -r '.config.digest // empty,(.layers // [])[]?.digest // empty')
+    )
 
     local digest
     for digest in ${digests[@]}; do
-        # Check if the layer already exists at the destination
+        # Check if the blob already exists at the destination
         local result=$(curl \
             --head \
             --header "Authorization: Bearer $TOKEN" \
@@ -369,7 +371,7 @@ copy_layers() {
         local status=$(echo "$result" | tail -n 1)
         result="$(echo "$result" | head -n -1)"
         if [[ "$status" == 200 ]]; then
-            echo "Layer $REGISTRY/$REPO_DST@$digest already exists"
+            echo "Blob $REGISTRY/$REPO_DST@$digest already exists"
         elif [[ "$status" == 404 ]]; then
             # If the layer doesn't already exist, copy it
             result=$(curl \
@@ -384,15 +386,15 @@ copy_layers() {
             status=$(echo "$result" | tail -n 1)
             result="$(echo "$result" | head -n -1)"
             if [[ "$status" != 201 ]]; then
-                echo "Failed to copy layer to '$REGISTRY/$REPO_DST@$digest'," \
+                echo "Failed to copy blob to '$REGISTRY/$REPO_DST@$digest'," \
                     "status=$status, details="
                 echo "$result"
                 return 1
             fi
 
-            echo "Pushed layer $REGISTRY/$REPO_DST@$digest"
-        else [[ "$status" != 200 ]]
-            echo "Failed to check existence of layer '$REGISTRY/$REPO_DST@$digest'," \
+            echo "Pushed blob $REGISTRY/$REPO_DST@$digest"
+        else
+            echo "Failed to check existence of blob '$REGISTRY/$REPO_DST@$digest'," \
                 "status=$status, details="
             echo "$result"
             return 1
@@ -467,10 +469,10 @@ copy_manifests() {
 
         if [[ -n "$dst_repo" ]] && [[ "$dst_repo" != "$REPOSITORY" ]]; then
             # If we're copying to a different repository, always push the manifest. But first, we
-            # might also need to copy the layers referenced in each manifest.
+            # might also need to copy the config/layer blobs referenced in each manifest.
             REFERENCE="$digest" pull_manifest
             local manifest="$OUTPUTS"
-            MANIFEST="$manifest" REPO_SRC="$REPOSITORY" REPO_DST="$dst_repo" copy_layers
+            MANIFEST="$manifest" REPO_SRC="$REPOSITORY" REPO_DST="$dst_repo" copy_blobs
             MANIFEST="$manifest" REPOSITORY="$dst_repo" REFERENCE="${tag:-$digest}" push_manifest
         elif [[ -n "$tag" ]]; then
             # If we're copying within the same repository, we only need to push tags, not digests


### PR DESCRIPTION
## Summary

Update the multi-platform image copy logic to support the OCI artifact attestation layout used by newer versions of BuildKit.

A release of the 1.5 Edge Agent image failed while copying the image from its staging repository to its public repository. The image used an OCI artifact attestation manifest containing a `subject` descriptor. The existing copy logic recursively selected every `digest` in the manifest and incorrectly treated `subject.digest`, which references another manifest, as a blob.

The registry could not mount that manifest digest through the blob API and returned `202 Accepted`, causing the publishing task to fail.

## Changes

- Rename `copy_layers` to `copy_blobs` to reflect that it copies both the image config and layer blobs.
- Select blob descriptors explicitly from `.config.digest` and `.layers[].digest`.
- Exclude other descriptors such as `.subject.digest`.
- Update related messages and comments to use "blob" terminology.
- Log Docker Engine, Buildx, BuildKit builder, daemon, and relevant environment information during image builds. This will make changes to the unpinned builder environment visible in future pipeline logs.

## Background

BuildKit 0.32 introduced OCI artifact storage as the default for attestations when OCI media types are enabled. In that layout, an attestation manifest contains descriptors similar to:

```json
{
  "config": {
    "digest": "<config blob>"
  },
  "layers": [
    {
      "digest": "<attestation blob>"
    }
  ],
  "subject": {
    "digest": "<platform image manifest>"
  }
}
```

Only `config.digest` and entries under `layers` are blobs that need to be mounted into the destination repository. `subject.digest` identifies the manifest to which the attestation applies and must not be sent to the blob API.

The updated selection also remains compatible with the previous BuildKit attestation representation and regular OCI and Docker image manifests.

To test, I added a temporary task to the CI build pipeline that uses `manifest-tools.sh` to copy the built images to another repository in the same registry, which exercises the updated script code. I examined the images to make sure everything was preserved. The temporary task was reverted once I completed my validation.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.