### PR TITLE
Fix edgeHub MQTT connection timeouts caused by DotNetty downgrade

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.7.6" />
+    <PackageReference Include="DotNetty.Handlers" Version="0.7.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageReference Include="Microsoft.Azure.Devices.ProtocolGateway.Core" Version="2.0.1" />
   </ItemGroup>

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/packages.lock.json
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/packages.lock.json
@@ -2,6 +2,30 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "DotNetty.Codecs.Mqtt": {
+        "type": "Direct",
+        "requested": "[0.7.6, )",
+        "resolved": "0.7.6",
+        "contentHash": "jVynN2g/HXPlaT+zZwdJENaB0Aw28iV7ZvttAXy0i1ST7MB3olKxTTy5tq2QuI4z4wFzMHx/+15znq06AcyIAw==",
+        "dependencies": {
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
+        }
+      },
+      "DotNetty.Handlers": {
+        "type": "Direct",
+        "requested": "[0.7.6, )",
+        "resolved": "0.7.6",
+        "contentHash": "6sSMp0Md8DbpyOAV9IjiR30uzaLrxAbJTcwFFpMJM1+EJhvPz6Ywt0RqoV6+lseq6zqBjMq2jbPTKcqPoqNYIA==",
+        "dependencies": {
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
+        }
+      },
       "Microsoft.Azure.Devices.ProtocolGateway.Core": {
         "type": "Direct",
         "requested": "[2.0.1, )",
@@ -109,65 +133,37 @@
       },
       "DotNetty.Buffers": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "MjxoFMdKsSJ5CLKTFHTKYoFUZUvC6VHGx71vPLSflmR/X4dSm57/hVxhsQY3YU6aASeRjqgNiCHn4II+UNOIWQ==",
+        "resolved": "0.7.6",
+        "contentHash": "JVYypDugRG4m3hbS0drCC79vX93zqjn5w+U4ti/KXjTIzcQ/UVHrCgs7ZgJfWRUQLfgfQB0daYQtE18lKD8pHg==",
         "dependencies": {
-          "DotNetty.Common": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Common": "0.7.6"
         }
       },
       "DotNetty.Codecs": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "gLAVaII7A4er3ZwUJIAZpynDLsxNr7Acw61OoCDfzIAkcB2L6OJ9jPnKy8YtrtTnJXm0lNod5+7aRJTmaBbT0Q==",
+        "resolved": "0.7.6",
+        "contentHash": "XBZy/m3+V8PBUHHHbFKaRBE0+knTCitcE8oKCQn4jZybH25mCZ1vTwj3BRuPYdNpzh74Op32Hj4ZXF+DMx/oAg==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
-        }
-      },
-      "DotNetty.Codecs.Mqtt": {
-        "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "EzZtHRxdLXE9ASFkcNvbO7CiVp7ldsAEx7gLEP62uo6CxlHn8yYPU7fiPJ4gZHGZFznHevwTD05WhAjEMgBEIw==",
-        "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Common": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "aVD0bWoaH+Ou0wOTFzYEs3hrzsckUEkbdweVgwHsk7q0OTPgmPD/QkGxjNqjZ9diUyeGvHzYn7mFQGG5cgbYUA==",
+        "resolved": "0.7.6",
+        "contentHash": "dmK8Njfh2Y4qnz99lLK0evoc46FPL5WOnHMLlavNZ6zqC5/bKgqGsJFoXbhVPkSYDp58g2euI64dhY0cvOUOZQ==",
         "dependencies": {
-          "Microsoft.Extensions.Logging": "1.1.1",
-          "NETStandard.Library": "1.6.1"
-        }
-      },
-      "DotNetty.Handlers": {
-        "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "LXj49DSk/PzC5r7MkXKpYit4t5DsUNpEw1m899SoV2gGVs9WooYUVyjOhKwyqBUPie4QgkYc6tsgAHNJUmDhbA==",
-        "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "Microsoft.Extensions.Logging": "5.0.0"
         }
       },
       "DotNetty.Transport": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "HLYcbZfLDIVPhtr+x3nv2vvxBxKONWXeP/B1LaXvPeSfdvlOtvoxB0tuv92SaOdqq9NUCjAP59Nn9xofRrt8mA==",
+        "resolved": "0.7.6",
+        "contentHash": "EVQ5FihFPdWmw7v6l/4iyMepj49vZT11kWQNJ0ApC4KzkdJJ6LM/7NDUgghyxbO0e25nfQRtkGLP5EZAEo7QDA==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Common": "0.7.6"
         }
       },
       "JetBrains.Annotations": {
@@ -182,8 +178,8 @@
       },
       "Microsoft.Azure.Devices.Client": {
         "type": "Transitive",
-        "resolved": "1.43.0-edgeLts",
-        "contentHash": "lmcZUT04unp09ZoY9RdXTHjjsZrKs1oFotyvOlZBpsYD06R0/CTpfjbuk54LOqkH0NDk2lErnPAH/+/FE04fMg==",
+        "resolved": "1.43.2-edgeLts",
+        "contentHash": "Is/Fed8WHB6E97Hjk2bgKmxH3daVWpNrMX+lJ2ZNJlDlh3PWxgbd1QMETap0cp7ahpn13YXEzvsWmjuZ//XvrQ==",
         "dependencies": {
           "MQTTnet": "5.1.0.1559",
           "Microsoft.Azure.Amqp": "2.6.9",
@@ -533,7 +529,7 @@
         "dependencies": {
           "App.Metrics": "[3.0.0, )",
           "JetBrains.Annotations": "[2018.3.0, )",
-          "Microsoft.Azure.Devices.Client": "[1.43.0-edgeLts, 1.43.0-edgeLts]",
+          "Microsoft.Azure.Devices.Client": "[1.43.2-edgeLts, 1.43.2-edgeLts]",
           "Microsoft.Azure.Devices.Edge.Storage": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.Routing.Core": "[1.0.0, )"

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/packages.lock.json
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/packages.lock.json
@@ -163,25 +163,23 @@
       },
       "DotNetty.Codecs": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "gLAVaII7A4er3ZwUJIAZpynDLsxNr7Acw61OoCDfzIAkcB2L6OJ9jPnKy8YtrtTnJXm0lNod5+7aRJTmaBbT0Q==",
+        "resolved": "0.7.6",
+        "contentHash": "XBZy/m3+V8PBUHHHbFKaRBE0+knTCitcE8oKCQn4jZybH25mCZ1vTwj3BRuPYdNpzh74Op32Hj4ZXF+DMx/oAg==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Codecs.Mqtt": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "EzZtHRxdLXE9ASFkcNvbO7CiVp7ldsAEx7gLEP62uo6CxlHn8yYPU7fiPJ4gZHGZFznHevwTD05WhAjEMgBEIw==",
+        "resolved": "0.7.6",
+        "contentHash": "jVynN2g/HXPlaT+zZwdJENaB0Aw28iV7ZvttAXy0i1ST7MB3olKxTTy5tq2QuI4z4wFzMHx/+15znq06AcyIAw==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Common": {
@@ -191,14 +189,13 @@
       },
       "DotNetty.Handlers": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "LXj49DSk/PzC5r7MkXKpYit4t5DsUNpEw1m899SoV2gGVs9WooYUVyjOhKwyqBUPie4QgkYc6tsgAHNJUmDhbA==",
+        "resolved": "0.7.6",
+        "contentHash": "6sSMp0Md8DbpyOAV9IjiR30uzaLrxAbJTcwFFpMJM1+EJhvPz6Ywt0RqoV6+lseq6zqBjMq2jbPTKcqPoqNYIA==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Transport": {
@@ -242,8 +239,8 @@
       },
       "Microsoft.Azure.Devices.Client": {
         "type": "Transitive",
-        "resolved": "1.43.0-edgeLts",
-        "contentHash": "lmcZUT04unp09ZoY9RdXTHjjsZrKs1oFotyvOlZBpsYD06R0/CTpfjbuk54LOqkH0NDk2lErnPAH/+/FE04fMg==",
+        "resolved": "1.43.2-edgeLts",
+        "contentHash": "Is/Fed8WHB6E97Hjk2bgKmxH3daVWpNrMX+lJ2ZNJlDlh3PWxgbd1QMETap0cp7ahpn13YXEzvsWmjuZ//XvrQ==",
         "dependencies": {
           "MQTTnet": "5.1.0.1559",
           "Microsoft.Azure.Amqp": "2.6.9",
@@ -520,7 +517,7 @@
         "dependencies": {
           "App.Metrics": "[3.0.0, )",
           "JetBrains.Annotations": "[2018.3.0, )",
-          "Microsoft.Azure.Devices.Client": "[1.43.0-edgeLts, 1.43.0-edgeLts]",
+          "Microsoft.Azure.Devices.Client": "[1.43.2-edgeLts, 1.43.2-edgeLts]",
           "Microsoft.Azure.Devices.Edge.Storage": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.Routing.Core": "[1.0.0, )"
@@ -537,6 +534,8 @@
       "microsoft.azure.devices.edge.hub.mqtt": {
         "type": "Project",
         "dependencies": {
+          "DotNetty.Codecs.Mqtt": "[0.7.6, )",
+          "DotNetty.Handlers": "[0.7.6, )",
           "Microsoft.Azure.Devices.Edge.Hub.Core": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.ProtocolGateway.Core": "[2.0.1, )"

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/packages.lock.json
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/packages.lock.json
@@ -211,25 +211,23 @@
       },
       "DotNetty.Codecs": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "gLAVaII7A4er3ZwUJIAZpynDLsxNr7Acw61OoCDfzIAkcB2L6OJ9jPnKy8YtrtTnJXm0lNod5+7aRJTmaBbT0Q==",
+        "resolved": "0.7.6",
+        "contentHash": "XBZy/m3+V8PBUHHHbFKaRBE0+knTCitcE8oKCQn4jZybH25mCZ1vTwj3BRuPYdNpzh74Op32Hj4ZXF+DMx/oAg==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Codecs.Mqtt": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "EzZtHRxdLXE9ASFkcNvbO7CiVp7ldsAEx7gLEP62uo6CxlHn8yYPU7fiPJ4gZHGZFznHevwTD05WhAjEMgBEIw==",
+        "resolved": "0.7.6",
+        "contentHash": "jVynN2g/HXPlaT+zZwdJENaB0Aw28iV7ZvttAXy0i1ST7MB3olKxTTy5tq2QuI4z4wFzMHx/+15znq06AcyIAw==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Common": {
@@ -242,14 +240,13 @@
       },
       "DotNetty.Handlers": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "LXj49DSk/PzC5r7MkXKpYit4t5DsUNpEw1m899SoV2gGVs9WooYUVyjOhKwyqBUPie4QgkYc6tsgAHNJUmDhbA==",
+        "resolved": "0.7.6",
+        "contentHash": "6sSMp0Md8DbpyOAV9IjiR30uzaLrxAbJTcwFFpMJM1+EJhvPz6Ywt0RqoV6+lseq6zqBjMq2jbPTKcqPoqNYIA==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Transport": {
@@ -296,8 +293,8 @@
       },
       "Microsoft.Azure.Devices.Client": {
         "type": "Transitive",
-        "resolved": "1.43.0-edgeLts",
-        "contentHash": "lmcZUT04unp09ZoY9RdXTHjjsZrKs1oFotyvOlZBpsYD06R0/CTpfjbuk54LOqkH0NDk2lErnPAH/+/FE04fMg==",
+        "resolved": "1.43.2-edgeLts",
+        "contentHash": "Is/Fed8WHB6E97Hjk2bgKmxH3daVWpNrMX+lJ2ZNJlDlh3PWxgbd1QMETap0cp7ahpn13YXEzvsWmjuZ//XvrQ==",
         "dependencies": {
           "MQTTnet": "5.1.0.1559",
           "Microsoft.Azure.Amqp": "2.6.9",
@@ -845,7 +842,7 @@
         "dependencies": {
           "App.Metrics": "[3.0.0, )",
           "JetBrains.Annotations": "[2018.3.0, )",
-          "Microsoft.Azure.Devices.Client": "[1.43.0-edgeLts, 1.43.0-edgeLts]",
+          "Microsoft.Azure.Devices.Client": "[1.43.2-edgeLts, 1.43.2-edgeLts]",
           "Microsoft.Azure.Devices.Edge.Storage": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.Routing.Core": "[1.0.0, )"
@@ -867,6 +864,8 @@
       "microsoft.azure.devices.edge.hub.mqtt": {
         "type": "Project",
         "dependencies": {
+          "DotNetty.Codecs.Mqtt": "[0.7.6, )",
+          "DotNetty.Handlers": "[0.7.6, )",
           "Microsoft.Azure.Devices.Edge.Hub.Core": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.ProtocolGateway.Core": "[2.0.1, )",
@@ -886,7 +885,7 @@
           "Azure.Identity": "[1.17.1, )",
           "Azure.Messaging.EventHubs": "[5.12.2, )",
           "Microsoft.Azure.Devices": "[1.42.0-edgeLts, 1.42.0-edgeLts]",
-          "Microsoft.Azure.Devices.Client": "[1.43.0-edgeLts, 1.43.0-edgeLts]",
+          "Microsoft.Azure.Devices.Client": "[1.43.2-edgeLts, 1.43.2-edgeLts]",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[10.0.0, )",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "[10.0.0, )",

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/packages.lock.json
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/packages.lock.json
@@ -213,25 +213,23 @@
       },
       "DotNetty.Codecs": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "gLAVaII7A4er3ZwUJIAZpynDLsxNr7Acw61OoCDfzIAkcB2L6OJ9jPnKy8YtrtTnJXm0lNod5+7aRJTmaBbT0Q==",
+        "resolved": "0.7.6",
+        "contentHash": "XBZy/m3+V8PBUHHHbFKaRBE0+knTCitcE8oKCQn4jZybH25mCZ1vTwj3BRuPYdNpzh74Op32Hj4ZXF+DMx/oAg==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Codecs.Mqtt": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "EzZtHRxdLXE9ASFkcNvbO7CiVp7ldsAEx7gLEP62uo6CxlHn8yYPU7fiPJ4gZHGZFznHevwTD05WhAjEMgBEIw==",
+        "resolved": "0.7.6",
+        "contentHash": "jVynN2g/HXPlaT+zZwdJENaB0Aw28iV7ZvttAXy0i1ST7MB3olKxTTy5tq2QuI4z4wFzMHx/+15znq06AcyIAw==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Common": {
@@ -244,14 +242,13 @@
       },
       "DotNetty.Handlers": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "LXj49DSk/PzC5r7MkXKpYit4t5DsUNpEw1m899SoV2gGVs9WooYUVyjOhKwyqBUPie4QgkYc6tsgAHNJUmDhbA==",
+        "resolved": "0.7.6",
+        "contentHash": "6sSMp0Md8DbpyOAV9IjiR30uzaLrxAbJTcwFFpMJM1+EJhvPz6Ywt0RqoV6+lseq6zqBjMq2jbPTKcqPoqNYIA==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Transport": {
@@ -301,8 +298,8 @@
       },
       "Microsoft.Azure.Devices.Client": {
         "type": "Transitive",
-        "resolved": "1.43.0-edgeLts",
-        "contentHash": "lmcZUT04unp09ZoY9RdXTHjjsZrKs1oFotyvOlZBpsYD06R0/CTpfjbuk54LOqkH0NDk2lErnPAH/+/FE04fMg==",
+        "resolved": "1.43.2-edgeLts",
+        "contentHash": "Is/Fed8WHB6E97Hjk2bgKmxH3daVWpNrMX+lJ2ZNJlDlh3PWxgbd1QMETap0cp7ahpn13YXEzvsWmjuZ//XvrQ==",
         "dependencies": {
           "MQTTnet": "5.1.0.1559",
           "Microsoft.Azure.Amqp": "2.6.9",
@@ -934,7 +931,7 @@
         "dependencies": {
           "App.Metrics": "[3.0.0, )",
           "JetBrains.Annotations": "[2018.3.0, )",
-          "Microsoft.Azure.Devices.Client": "[1.43.0-edgeLts, 1.43.0-edgeLts]",
+          "Microsoft.Azure.Devices.Client": "[1.43.2-edgeLts, 1.43.2-edgeLts]",
           "Microsoft.Azure.Devices.Edge.Storage": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.Routing.Core": "[1.0.0, )"
@@ -964,6 +961,8 @@
       "microsoft.azure.devices.edge.hub.mqtt": {
         "type": "Project",
         "dependencies": {
+          "DotNetty.Codecs.Mqtt": "[0.7.6, )",
+          "DotNetty.Handlers": "[0.7.6, )",
           "Microsoft.Azure.Devices.Edge.Hub.Core": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.ProtocolGateway.Core": "[2.0.1, )",
@@ -1008,7 +1007,7 @@
           "Azure.Identity": "[1.17.1, )",
           "Azure.Messaging.EventHubs": "[5.12.2, )",
           "Microsoft.Azure.Devices": "[1.42.0-edgeLts, 1.42.0-edgeLts]",
-          "Microsoft.Azure.Devices.Client": "[1.43.0-edgeLts, 1.43.0-edgeLts]",
+          "Microsoft.Azure.Devices.Client": "[1.43.2-edgeLts, 1.43.2-edgeLts]",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[10.0.0, )",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "[10.0.0, )",

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/packages.lock.json
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/packages.lock.json
@@ -154,25 +154,23 @@
       },
       "DotNetty.Codecs": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "gLAVaII7A4er3ZwUJIAZpynDLsxNr7Acw61OoCDfzIAkcB2L6OJ9jPnKy8YtrtTnJXm0lNod5+7aRJTmaBbT0Q==",
+        "resolved": "0.7.6",
+        "contentHash": "XBZy/m3+V8PBUHHHbFKaRBE0+knTCitcE8oKCQn4jZybH25mCZ1vTwj3BRuPYdNpzh74Op32Hj4ZXF+DMx/oAg==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Codecs.Mqtt": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "EzZtHRxdLXE9ASFkcNvbO7CiVp7ldsAEx7gLEP62uo6CxlHn8yYPU7fiPJ4gZHGZFznHevwTD05WhAjEMgBEIw==",
+        "resolved": "0.7.6",
+        "contentHash": "jVynN2g/HXPlaT+zZwdJENaB0Aw28iV7ZvttAXy0i1ST7MB3olKxTTy5tq2QuI4z4wFzMHx/+15znq06AcyIAw==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Common": {
@@ -185,14 +183,13 @@
       },
       "DotNetty.Handlers": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "LXj49DSk/PzC5r7MkXKpYit4t5DsUNpEw1m899SoV2gGVs9WooYUVyjOhKwyqBUPie4QgkYc6tsgAHNJUmDhbA==",
+        "resolved": "0.7.6",
+        "contentHash": "6sSMp0Md8DbpyOAV9IjiR30uzaLrxAbJTcwFFpMJM1+EJhvPz6Ywt0RqoV6+lseq6zqBjMq2jbPTKcqPoqNYIA==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Transport": {
@@ -228,8 +225,8 @@
       },
       "Microsoft.Azure.Devices.Client": {
         "type": "Transitive",
-        "resolved": "1.43.0-edgeLts",
-        "contentHash": "lmcZUT04unp09ZoY9RdXTHjjsZrKs1oFotyvOlZBpsYD06R0/CTpfjbuk54LOqkH0NDk2lErnPAH/+/FE04fMg==",
+        "resolved": "1.43.2-edgeLts",
+        "contentHash": "Is/Fed8WHB6E97Hjk2bgKmxH3daVWpNrMX+lJ2ZNJlDlh3PWxgbd1QMETap0cp7ahpn13YXEzvsWmjuZ//XvrQ==",
         "dependencies": {
           "MQTTnet": "5.1.0.1559",
           "Microsoft.Azure.Amqp": "2.6.9",
@@ -745,7 +742,7 @@
         "dependencies": {
           "App.Metrics": "[3.0.0, )",
           "JetBrains.Annotations": "[2018.3.0, )",
-          "Microsoft.Azure.Devices.Client": "[1.43.0-edgeLts, 1.43.0-edgeLts]",
+          "Microsoft.Azure.Devices.Client": "[1.43.2-edgeLts, 1.43.2-edgeLts]",
           "Microsoft.Azure.Devices.Edge.Storage": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.Routing.Core": "[1.0.0, )"
@@ -767,6 +764,8 @@
       "microsoft.azure.devices.edge.hub.mqtt": {
         "type": "Project",
         "dependencies": {
+          "DotNetty.Codecs.Mqtt": "[0.7.6, )",
+          "DotNetty.Handlers": "[0.7.6, )",
           "Microsoft.Azure.Devices.Edge.Hub.Core": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.ProtocolGateway.Core": "[2.0.1, )",

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Service.Test/packages.lock.json
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Service.Test/packages.lock.json
@@ -151,25 +151,23 @@
       },
       "DotNetty.Codecs": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "gLAVaII7A4er3ZwUJIAZpynDLsxNr7Acw61OoCDfzIAkcB2L6OJ9jPnKy8YtrtTnJXm0lNod5+7aRJTmaBbT0Q==",
+        "resolved": "0.7.6",
+        "contentHash": "XBZy/m3+V8PBUHHHbFKaRBE0+knTCitcE8oKCQn4jZybH25mCZ1vTwj3BRuPYdNpzh74Op32Hj4ZXF+DMx/oAg==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Codecs.Mqtt": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "EzZtHRxdLXE9ASFkcNvbO7CiVp7ldsAEx7gLEP62uo6CxlHn8yYPU7fiPJ4gZHGZFznHevwTD05WhAjEMgBEIw==",
+        "resolved": "0.7.6",
+        "contentHash": "jVynN2g/HXPlaT+zZwdJENaB0Aw28iV7ZvttAXy0i1ST7MB3olKxTTy5tq2QuI4z4wFzMHx/+15znq06AcyIAw==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Common": {
@@ -182,14 +180,13 @@
       },
       "DotNetty.Handlers": {
         "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "LXj49DSk/PzC5r7MkXKpYit4t5DsUNpEw1m899SoV2gGVs9WooYUVyjOhKwyqBUPie4QgkYc6tsgAHNJUmDhbA==",
+        "resolved": "0.7.6",
+        "contentHash": "6sSMp0Md8DbpyOAV9IjiR30uzaLrxAbJTcwFFpMJM1+EJhvPz6Ywt0RqoV6+lseq6zqBjMq2jbPTKcqPoqNYIA==",
         "dependencies": {
-          "DotNetty.Buffers": "0.6.0",
-          "DotNetty.Codecs": "0.6.0",
-          "DotNetty.Common": "0.6.0",
-          "DotNetty.Transport": "0.6.0",
-          "NETStandard.Library": "1.6.1"
+          "DotNetty.Buffers": "0.7.6",
+          "DotNetty.Codecs": "0.7.6",
+          "DotNetty.Common": "0.7.6",
+          "DotNetty.Transport": "0.7.6"
         }
       },
       "DotNetty.Transport": {
@@ -251,8 +248,8 @@
       },
       "Microsoft.Azure.Devices.Client": {
         "type": "Transitive",
-        "resolved": "1.43.0-edgeLts",
-        "contentHash": "lmcZUT04unp09ZoY9RdXTHjjsZrKs1oFotyvOlZBpsYD06R0/CTpfjbuk54LOqkH0NDk2lErnPAH/+/FE04fMg==",
+        "resolved": "1.43.2-edgeLts",
+        "contentHash": "Is/Fed8WHB6E97Hjk2bgKmxH3daVWpNrMX+lJ2ZNJlDlh3PWxgbd1QMETap0cp7ahpn13YXEzvsWmjuZ//XvrQ==",
         "dependencies": {
           "MQTTnet": "5.1.0.1559",
           "Microsoft.Azure.Amqp": "2.6.9",
@@ -824,7 +821,7 @@
         "dependencies": {
           "App.Metrics": "[3.0.0, )",
           "JetBrains.Annotations": "[2018.3.0, )",
-          "Microsoft.Azure.Devices.Client": "[1.43.0-edgeLts, 1.43.0-edgeLts]",
+          "Microsoft.Azure.Devices.Client": "[1.43.2-edgeLts, 1.43.2-edgeLts]",
           "Microsoft.Azure.Devices.Edge.Storage": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.Routing.Core": "[1.0.0, )"
@@ -841,6 +838,8 @@
       "microsoft.azure.devices.edge.hub.mqtt": {
         "type": "Project",
         "dependencies": {
+          "DotNetty.Codecs.Mqtt": "[0.7.6, )",
+          "DotNetty.Handlers": "[0.7.6, )",
           "Microsoft.Azure.Devices.Edge.Hub.Core": "[1.0.0, )",
           "Microsoft.Azure.Devices.Edge.Util": "[1.0.0, )",
           "Microsoft.Azure.Devices.ProtocolGateway.Core": "[2.0.1, )",


### PR DESCRIPTION
Summary
Fixes an edgeHub MQTT/TLS failure where the client completes TLS and sends MQTT CONNECT, but edgeHub does not receive the decrypted MQTT packet and therefore never returns CONNACK.

Root cause
The .NET 10 and Device SDK update removed a transitive dependency that previously raised DotNetty to 0.7.6. Microsoft.Azure.Devices.ProtocolGateway.Core 2.0.1 still declares 0.6.0, causing NuGet to resolve the MQTT server stack back to DotNetty 0.6.0.

DotNetty 0.6.0 can lose application data received around TLS handshake completion, particularly when the final TLS flight and MQTT CONNECT arrive together with AutoRead=false.

Fix
- Add direct references to DotNetty.Codecs.Mqtt and DotNetty.Handlers 0.7.6.

Validation
- A controlled .NET 10 TLS reproduction produced:

- DotNetty 0.6.0, TLS + MQTT: 0/30 delivered
- DotNetty 0.7.6, same input: 30/30 delivered


Repository validation:

Release build succeeded.
All 192 MQTT unit tests passed.
Generated runtime manifest contains only DotNetty 0.7.6 packages.
No DotNetty 0.6.0 runtime assets remain.


## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.