### PR TITLE
Restrict host bind sources for unprivileged modules

### DIFF
--- a/edgelet/contrib/config/linux/default.toml
+++ b/edgelet/contrib/config/linux/default.toml
@@ -6,6 +6,8 @@
 
 homedir = "/var/lib/aziot/edged"
 
+allowed_bind_sources = ["/iotedge/storage"]
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/contrib/config/linux/template.toml
+++ b/edgelet/contrib/config/linux/template.toml
@@ -42,6 +42,14 @@
 # line to improve the security of the device.
 #
 # allow_elevated_docker_permissions = false
+#
+# When elevated Docker permissions are disabled, only bind mounts whose host source
+# is this path or one of its descendants are retained. IoT Edge workload sockets and
+# the Edge Agent management socket are allow-listed automatically. Disallowed binds are
+# removed and logged. Set this to [] to disallow all other host bind sources.
+#
+# Paths are normalized before comparison.
+allowed_bind_sources = ["/iotedge/storage"]
 
 # ==============================================================================
 # Module identity cache preference

--- a/edgelet/docker-rs/src/models/host_config.rs
+++ b/edgelet/docker-rs/src/models/host_config.rs
@@ -18,6 +18,8 @@ pub struct HostConfig {
     pub extra_hosts: Option<Vec<String>>,
     #[serde(rename = "Privileged", skip_serializing_if = "Option::is_none")]
     pub privileged: Option<bool>,
+    #[serde(rename = "VolumesFrom", skip_serializing_if = "Option::is_none")]
+    pub volumes_from: Option<Vec<String>>,
     #[serde(flatten)]
     pub other_properties: std::collections::BTreeMap<String, serde_json::Value>,
 }

--- a/edgelet/docker-rs/src/models/mod.rs
+++ b/edgelet/docker-rs/src/models/mod.rs
@@ -41,7 +41,7 @@ mod container_top_response;
 pub use self::container_top_response::ContainerTopResponse;
 
 mod host_config;
-pub use self::host_config::{HostConfig, HostConfigPortBindings};
+pub use self::host_config::{HostConfig, HostConfigPortBindings, Mount};
 
 mod image_summary;
 pub use self::image_summary::ImageSummary;

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 use std::collections::{BTreeMap, HashMap};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{process, str};
@@ -42,8 +43,27 @@ pub struct DockerModuleRuntime<C> {
     system_resources: Arc<Mutex<System>>,
     create_socket_channel: UnboundedSender<ModuleAction>,
     allow_elevated_docker_permissions: bool,
+    allowed_bind_sources: Vec<PathBuf>,
+    workload_socket_dir: PathBuf,
+    management_socket: Option<PathBuf>,
+    agent_name: String,
     additional_info: BTreeMap<String, String>,
     image_use_data: ImagePruneData,
+}
+
+impl<C> DockerModuleRuntime<C> {
+    // Each module may access only its own workload socket; only Edge Agent may access management.
+    fn implicit_bind_sources(&self, module_name: &str) -> Vec<PathBuf> {
+        let mut sources = vec![self.workload_socket_dir.join(format!("{module_name}.sock"))];
+
+        if module_name == self.agent_name
+            && let Some(management_socket) = &self.management_socket
+        {
+            sources.push(management_socket.clone());
+        }
+
+        sources
+    }
 }
 
 fn merge_env(cur_env: Option<&[String]>, new_env: &BTreeMap<String, String>) -> Vec<String> {
@@ -184,11 +204,18 @@ impl MakeModuleRuntime for DockerModuleRuntime<Connector> {
         let system_resources = System::new_all();
         log::info!("Successfully initialized module runtime");
 
+        let workload_socket_dir = settings.homedir().canonicalize()?.join("mnt");
+        let management_socket = socket_path(settings.connect().management_uri());
+
         let runtime = Self {
             client,
             system_resources: Arc::new(Mutex::new(system_resources)),
             create_socket_channel,
             allow_elevated_docker_permissions: settings.allow_elevated_docker_permissions(),
+            allowed_bind_sources: settings.allowed_bind_sources().to_vec(),
+            workload_socket_dir,
+            management_socket,
+            agent_name: settings.agent().name().to_owned(),
             additional_info: settings.additional_info().clone(),
             image_use_data,
         };
@@ -326,6 +353,15 @@ where
         );
         drop_unsafe_privileges(
             self.allow_elevated_docker_permissions,
+            module.config_mut().create_options_mut(),
+        );
+        let module_name = module.name().to_owned();
+        let implicit_bind_sources = self.implicit_bind_sources(&module_name);
+        filter_bind_sources(
+            self.allow_elevated_docker_permissions,
+            &self.allowed_bind_sources,
+            &implicit_bind_sources,
+            &module_name,
             module.config_mut().create_options_mut(),
         );
 
@@ -939,11 +975,204 @@ fn drop_unsafe_privileges(
     host_config.cap_drop = Some(caps_to_drop);
 }
 
+fn socket_path(uri: &Url) -> Option<PathBuf> {
+    (uri.scheme() == "unix").then(|| PathBuf::from(uri.path()))
+}
+
+// TODO(rustup): Replace with Path::normalize_lexically when it is stabilized.
+fn normalize_lexically(path: &Path) -> Option<PathBuf> {
+    if !path.is_absolute() {
+        return None;
+    }
+
+    let mut normalized = PathBuf::from("/");
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::Normal(component) => normalized.push(component),
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            Component::Prefix(_) => return None,
+        }
+    }
+
+    Some(normalized)
+}
+
+fn is_allowed_bind_source(
+    source: &Path,
+    allowed_bind_sources: &[PathBuf],
+    implicit_bind_sources: &[PathBuf],
+) -> bool {
+    let Some(source) = normalize_lexically(source) else {
+        return false;
+    };
+
+    // Runtime sockets require exact matches;
+    // configured sources allow all descendants.
+    implicit_bind_sources
+        .iter()
+        .filter_map(|path| normalize_lexically(path))
+        .any(|path| source == path)
+        || allowed_bind_sources
+            .iter()
+            .filter_map(|path| normalize_lexically(path))
+            .any(|path| source.starts_with(path))
+}
+
+fn remove_case_insensitive_keys(
+    properties: &mut BTreeMap<String, serde_json::Value>,
+    keys: &[&str],
+) -> bool {
+    let original_len = properties.len();
+    properties.retain(|property, _| {
+        property.is_ascii() && !keys.iter().any(|key| property.eq_ignore_ascii_case(key))
+    });
+    properties.len() != original_len
+}
+
+fn has_volume_driver_config(properties: &BTreeMap<String, serde_json::Value>) -> bool {
+    properties
+        .iter()
+        .filter(|(property, _)| property.eq_ignore_ascii_case("VolumeOptions"))
+        .filter_map(|(_, value)| value.as_object())
+        .any(|options| {
+            options.iter().any(|(property, value)| {
+                !property.is_ascii()
+                    || (property.eq_ignore_ascii_case("DriverConfig") && !value.is_null())
+            })
+        })
+}
+
+fn filter_bind_sources(
+    allow_elevated_docker_permissions: bool,
+    allowed_bind_sources: &[PathBuf],
+    implicit_bind_sources: &[PathBuf],
+    module_name: &str,
+    create_options: &mut ContainerCreateBody,
+) {
+    if allow_elevated_docker_permissions {
+        return;
+    }
+
+    if remove_case_insensitive_keys(&mut create_options.other_properties, &["HostConfig"]) {
+        log::warn!(
+            "Removing ambiguous `HostConfig` from module '{module_name}'. Docker field names cannot differ only by case."
+        );
+    }
+
+    let Some(host_config) = &mut create_options.host_config else {
+        return;
+    };
+
+    if remove_case_insensitive_keys(
+        &mut host_config.other_properties,
+        &[
+            "Binds",
+            "Mounts",
+            "VolumesFrom",
+            "Privileged",
+            "CapAdd",
+            "CapDrop",
+        ],
+    ) {
+        log::warn!(
+            "Removing ambiguous Docker permission fields from module '{module_name}'. Docker field names cannot differ only by case."
+        );
+    }
+
+    if let Some(binds) = &mut host_config.binds {
+        binds.retain(|bind| {
+            let Some((source, _)) = bind.split_once(':') else {
+                return true;
+            };
+            if source.is_empty() {
+                log::warn!("Removing malformed bind '{bind}' from module '{module_name}'.");
+                return false;
+            }
+            let source = Path::new(source);
+            if !source.is_absolute() {
+                return true;
+            }
+
+            let allowed =
+                is_allowed_bind_source(source, allowed_bind_sources, implicit_bind_sources);
+
+            if !allowed {
+                log::warn!(
+                    "Removing disallowed host bind '{bind}' from module '{module_name}'. Add its source to `allowed_bind_sources` in config.toml to allow it."
+                );
+            }
+
+            allowed
+        });
+    }
+
+    if let Some(mounts) = &mut host_config.mounts {
+        mounts.retain(|mount| {
+            if mount.other_properties.keys().any(|property| {
+                !property.is_ascii()
+                    || property.eq_ignore_ascii_case("Source")
+                    || property.eq_ignore_ascii_case("Type")
+            }) {
+                log::warn!(
+                    "Removing mount with ambiguous source or type from module '{module_name}'. Docker field names cannot differ only by case."
+                );
+                return false;
+            }
+
+            if mount.r#type.as_deref() == Some("volume")
+                && has_volume_driver_config(&mount.other_properties)
+            {
+                log::warn!(
+                    "Removing volume mount with driver configuration from module '{module_name}'. Volume drivers can expose disallowed host paths."
+                );
+                return false;
+            }
+
+            if mount.r#type.as_deref() != Some("bind") {
+                return true;
+            }
+
+            let allowed = mount.source.as_deref().is_some_and(|source| {
+                is_allowed_bind_source(
+                    Path::new(source),
+                    allowed_bind_sources,
+                    implicit_bind_sources,
+                )
+            });
+
+            if !allowed {
+                log::warn!(
+                    "Removing disallowed host bind mount '{:?}' from module '{module_name}'. Add its source to `allowed_bind_sources` in config.toml to allow it.",
+                    mount.source
+                );
+            }
+
+            allowed
+        });
+    }
+
+    if host_config
+        .volumes_from
+        .as_ref()
+        .is_some_and(|volumes_from| !volumes_from.is_empty())
+    {
+        log::warn!(
+            "Removing `VolumesFrom` from module '{module_name}'. Inherited volumes can expose disallowed host paths."
+        );
+        host_config.volumes_from = None;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::process::{Command, Stdio};
 
-    use docker::models::HostConfig;
+    use docker::models::{HostConfig, Mount};
 
     use super::*;
 
@@ -1117,6 +1346,280 @@ mod tests {
         assert_eq!(
             create_options.host_config.as_ref().unwrap().cap_drop,
             Some(vec!["SETUID".to_owned()])
+        );
+    }
+
+    #[test]
+    fn filter_bind_sources_does_nothing_when_elevated_permissions_are_allowed() {
+        let mut create_options = ContainerCreateBody {
+            host_config: Some(HostConfig {
+                binds: Some(vec!["/:/host".to_owned()]),
+                mounts: Some(vec![Mount {
+                    source: Some("/var/run/docker.sock".to_owned()),
+                    target: Some("/var/run/docker.sock".to_owned()),
+                    r#type: Some("bind".to_owned()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        filter_bind_sources(true, &[], &[], "module1", &mut create_options);
+
+        let host_config = create_options.host_config.unwrap();
+        assert_eq!(host_config.binds, Some(vec!["/:/host".to_owned()]));
+        assert_eq!(host_config.mounts.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn filter_bind_sources_uses_normalized_component_prefixes() {
+        let mut create_options = ContainerCreateBody {
+            host_config: Some(HostConfig {
+                binds: Some(vec![
+                    "/iotedge/storage:/storage".to_owned(),
+                    "/iotedge/storage/module/./data:/data:ro".to_owned(),
+                    "/iotedge/storage-other:/collision".to_owned(),
+                    "/iotedge/storage/../../etc:/etc".to_owned(),
+                    "named-volume:/volume".to_owned(),
+                    "/anonymous".to_owned(),
+                    ":/malformed".to_owned(),
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        filter_bind_sources(
+            false,
+            &[PathBuf::from("/iotedge/storage")],
+            &[],
+            "module1",
+            &mut create_options,
+        );
+
+        assert_eq!(
+            create_options.host_config.unwrap().binds,
+            Some(vec![
+                "/iotedge/storage:/storage".to_owned(),
+                "/iotedge/storage/module/./data:/data:ro".to_owned(),
+                "named-volume:/volume".to_owned(),
+                "/anonymous".to_owned(),
+            ])
+        );
+    }
+
+    #[test]
+    fn filter_bind_sources_filters_only_structured_bind_mounts() {
+        let mut create_options = ContainerCreateBody {
+            host_config: Some(HostConfig {
+                mounts: Some(vec![
+                    Mount {
+                        source: Some("/iotedge/storage/edgeHub".to_owned()),
+                        target: Some("/storage".to_owned()),
+                        r#type: Some("bind".to_owned()),
+                        read_only: Some(true),
+                        ..Default::default()
+                    },
+                    Mount {
+                        source: Some("/var/run/docker.sock".to_owned()),
+                        target: Some("/var/run/docker.sock".to_owned()),
+                        r#type: Some("bind".to_owned()),
+                        ..Default::default()
+                    },
+                    Mount {
+                        source: Some("named-volume".to_owned()),
+                        target: Some("/volume".to_owned()),
+                        r#type: Some("volume".to_owned()),
+                        ..Default::default()
+                    },
+                    Mount {
+                        source: Some("driver-volume".to_owned()),
+                        target: Some("/host".to_owned()),
+                        r#type: Some("volume".to_owned()),
+                        other_properties: [(
+                            "VolumeOptions".to_owned(),
+                            serde_json::json!({
+                                "DriverConfig": {
+                                    "Name": "local",
+                                    "Options": {
+                                        "type": "none",
+                                        "o": "bind",
+                                        "device": "/"
+                                    }
+                                }
+                            }),
+                        )]
+                        .into(),
+                        ..Default::default()
+                    },
+                    Mount {
+                        source: None,
+                        target: Some("/missing".to_owned()),
+                        r#type: Some("bind".to_owned()),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        filter_bind_sources(
+            false,
+            &[PathBuf::from("/iotedge/storage")],
+            &[],
+            "edgeHub",
+            &mut create_options,
+        );
+
+        let mounts = create_options.host_config.unwrap().mounts.unwrap();
+        assert_eq!(mounts.len(), 2);
+        assert_eq!(
+            mounts[0].source.as_deref(),
+            Some("/iotedge/storage/edgeHub")
+        );
+        assert_eq!(mounts[0].read_only, Some(true));
+        assert_eq!(mounts[1].r#type.as_deref(), Some("volume"));
+    }
+
+    #[test]
+    fn filter_bind_sources_removes_inherited_volumes() {
+        let mut create_options = ContainerCreateBody {
+            host_config: Some(HostConfig {
+                volumes_from: Some(vec!["other-container".to_owned()]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        filter_bind_sources(false, &[], &[], "module1", &mut create_options);
+
+        assert_eq!(create_options.host_config.unwrap().volumes_from, None);
+    }
+
+    #[test]
+    fn filter_bind_sources_removes_case_insensitive_field_collisions() {
+        let mut create_options = ContainerCreateBody {
+            host_config: Some(HostConfig {
+                mounts: Some(vec![
+                    Mount {
+                        source: Some("driver-volume".to_owned()),
+                        target: Some("/host".to_owned()),
+                        r#type: Some("volume".to_owned()),
+                        other_properties: [(
+                            "volumeOptions".to_owned(),
+                            serde_json::json!({
+                                "driverConfig": {
+                                    "Name": "local",
+                                    "Options": {
+                                        "type": "none",
+                                        "o": "bind",
+                                        "device": "/"
+                                    }
+                                }
+                            }),
+                        )]
+                        .into(),
+                        ..Default::default()
+                    },
+                    Mount {
+                        source: Some("/iotedge/storage".to_owned()),
+                        target: Some("/storage".to_owned()),
+                        r#type: Some("bind".to_owned()),
+                        other_properties: [(
+                            "source".to_owned(),
+                            serde_json::Value::String("/".to_owned()),
+                        )]
+                        .into(),
+                        ..Default::default()
+                    },
+                ]),
+                other_properties: [
+                    ("binds".to_owned(), serde_json::json!(["/:/host"])),
+                    ("volumesFrom".to_owned(), serde_json::json!(["other"])),
+                    ("privileged".to_owned(), serde_json::Value::Bool(true)),
+                    ("capDrop".to_owned(), serde_json::json!([])),
+                ]
+                .into(),
+                ..Default::default()
+            }),
+            other_properties: [(
+                "Ho\u{17f}tConfig".to_owned(),
+                serde_json::json!({"Binds": ["/:/host"]}),
+            )]
+            .into(),
+            ..Default::default()
+        };
+
+        filter_bind_sources(
+            false,
+            &[PathBuf::from("/iotedge/storage")],
+            &[],
+            "module1",
+            &mut create_options,
+        );
+
+        assert!(create_options.other_properties.is_empty());
+        let host_config = create_options.host_config.unwrap();
+        assert!(host_config.other_properties.is_empty());
+        assert!(host_config.mounts.unwrap().is_empty());
+    }
+
+    #[test]
+    fn filter_bind_sources_preserves_required_runtime_sockets() {
+        let mut create_options = ContainerCreateBody {
+            host_config: Some(HostConfig {
+                binds: Some(vec![
+                    "/var/lib/aziot/edged/mnt/edgeAgent.sock:/var/run/iotedge/workload.sock"
+                        .to_owned(),
+                    "/var/run/iotedge/mgmt.sock:/var/run/iotedge/mgmt.sock".to_owned(),
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        filter_bind_sources(
+            false,
+            &[],
+            &[
+                PathBuf::from("/var/lib/aziot/edged/mnt/edgeAgent.sock"),
+                PathBuf::from("/var/run/iotedge/mgmt.sock"),
+            ],
+            "edgeAgent",
+            &mut create_options,
+        );
+
+        assert_eq!(
+            create_options
+                .host_config
+                .as_ref()
+                .unwrap()
+                .binds
+                .as_ref()
+                .unwrap()
+                .len(),
+            2
+        );
+
+        create_options.host_config.as_mut().unwrap().binds = Some(vec![
+            "/var/lib/aziot/edged/mnt/module1.sock:/var/run/iotedge/workload.sock".to_owned(),
+            "/var/run/iotedge/mgmt.sock:/var/run/iotedge/mgmt.sock".to_owned(),
+        ]);
+        filter_bind_sources(
+            false,
+            &[],
+            &[PathBuf::from("/var/lib/aziot/edged/mnt/module1.sock")],
+            "module1",
+            &mut create_options,
+        );
+
+        assert_eq!(
+            create_options.host_config.unwrap().binds,
+            Some(vec![
+                "/var/lib/aziot/edged/mnt/module1.sock:/var/run/iotedge/workload.sock".to_owned()
+            ])
         );
     }
 

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1094,7 +1094,8 @@ fn filter_bind_sources(
                 return false;
             }
             let source = Path::new(source);
-            // A non-absolute source in Binds is a Docker-managed named volume, not a host path.
+            // A non-absolute source in Binds is interpreted as a Docker volume name,
+            // not as a host filesystem path.
             if !source.is_absolute() {
                 return true;
             }

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1060,7 +1060,7 @@ fn filter_bind_sources(
 
     if remove_case_insensitive_keys(&mut create_options.other_properties, &["HostConfig"]) {
         log::warn!(
-            "Removing ambiguous `HostConfig` from module '{module_name}'. Docker field names cannot differ only by case."
+            "Removing case-insensitive duplicate of Docker field `HostConfig` from module '{module_name}'."
         );
     }
 
@@ -1080,7 +1080,7 @@ fn filter_bind_sources(
         ],
     ) {
         log::warn!(
-            "Removing ambiguous Docker permission fields from module '{module_name}'. Docker field names cannot differ only by case."
+            "Removing case-insensitive duplicate Docker permission fields from module '{module_name}'."
         );
     }
 
@@ -1094,6 +1094,7 @@ fn filter_bind_sources(
                 return false;
             }
             let source = Path::new(source);
+            // A non-absolute source in Binds is a Docker-managed named volume, not a host path.
             if !source.is_absolute() {
                 return true;
             }
@@ -1119,7 +1120,7 @@ fn filter_bind_sources(
                     || property.eq_ignore_ascii_case("Type")
             }) {
                 log::warn!(
-                    "Removing mount with ambiguous source or type from module '{module_name}'. Docker field names cannot differ only by case."
+                    "Removing mount with a case-insensitive duplicate source or type from module '{module_name}'."
                 );
                 return false;
             }
@@ -1158,13 +1159,12 @@ fn filter_bind_sources(
 
     if host_config
         .volumes_from
-        .as_ref()
+        .take()
         .is_some_and(|volumes_from| !volumes_from.is_empty())
     {
         log::warn!(
             "Removing `VolumesFrom` from module '{module_name}'. Inherited volumes can expose disallowed host paths."
         );
-        host_config.volumes_from = None;
     }
 }
 

--- a/edgelet/edgelet-settings/src/base/mod.rs
+++ b/edgelet/edgelet-settings/src/base/mod.rs
@@ -25,6 +25,8 @@ pub trait RuntimeSettings {
 
     fn allow_elevated_docker_permissions(&self) -> bool;
 
+    fn allowed_bind_sources(&self) -> &[std::path::PathBuf];
+
     fn iotedge_max_requests(&self) -> &IotedgeMaxRequests;
 
     fn agent(&self) -> &module::Settings<Self::ModuleConfig>;
@@ -104,6 +106,9 @@ pub struct Settings<ModuleConfig> {
     #[serde(default = "default_allow_elevated_docker_permissions")]
     pub allow_elevated_docker_permissions: bool,
 
+    #[serde(default)]
+    pub allowed_bind_sources: Vec<std::path::PathBuf>,
+
     #[serde(default, skip_serializing_if = "IotedgeMaxRequests::is_default")]
     pub iotedge_max_requests: IotedgeMaxRequests,
 
@@ -181,6 +186,10 @@ impl<T: Clone> RuntimeSettings for Settings<T> {
 
     fn allow_elevated_docker_permissions(&self) -> bool {
         self.allow_elevated_docker_permissions
+    }
+
+    fn allowed_bind_sources(&self) -> &[std::path::PathBuf] {
+        &self.allowed_bind_sources
     }
 
     fn agent(&self) -> &module::Settings<Self::ModuleConfig> {

--- a/edgelet/edgelet-settings/src/docker/mod.rs
+++ b/edgelet/edgelet-settings/src/docker/mod.rs
@@ -99,6 +99,10 @@ impl crate::RuntimeSettings for Settings {
         self.base.allow_elevated_docker_permissions()
     }
 
+    fn allowed_bind_sources(&self) -> &[std::path::PathBuf] {
+        self.base.allowed_bind_sources()
+    }
+
     fn agent(&self) -> &crate::module::Settings<Self::ModuleConfig> {
         self.base.agent()
     }
@@ -155,6 +159,9 @@ mod tests {
     static GOOD_SETTINGS_CONTENT_TRUST: &str = "test-files/sample_settings_content_trust.toml";
     static GOOD_SETTINGS_NETWORK: &str = "test-files/sample_settings.network.toml";
     static GOOD_SETTINGS_IMAGE_GC: &str = "test-files/sample_settings_image_gc.toml";
+    static GOOD_SETTINGS_ALLOWED_BINDS: &str = "test-files/sample_settings.allowed_binds.toml";
+    static GOOD_SETTINGS_NO_ALLOWED_BINDS: &str =
+        "test-files/sample_settings.no_allowed_binds.toml";
 
     #[test]
     fn err_no_file() {
@@ -210,6 +217,41 @@ mod tests {
         let settings = Settings::new().unwrap();
         let watchdog_settings = settings.watchdog();
         assert_eq!(watchdog_settings.max_retries(), 3);
+    }
+
+    #[test]
+    fn allowed_bind_sources_defaults() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock poisoned");
+        unsafe {
+            std::env::set_var("AZIOT_EDGED_CONFIG", GOOD_SETTINGS);
+            std::env::set_var("AZIOT_EDGED_CONFIG_DIR", CONFIG_DIR);
+        }
+        let settings = Settings::new().unwrap();
+
+        assert!(settings.allowed_bind_sources().is_empty());
+    }
+
+    #[test]
+    fn allowed_bind_sources_can_be_overridden_or_cleared() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock poisoned");
+        unsafe {
+            std::env::set_var("AZIOT_EDGED_CONFIG", GOOD_SETTINGS_ALLOWED_BINDS);
+            std::env::set_var("AZIOT_EDGED_CONFIG_DIR", CONFIG_DIR);
+        }
+        let settings = Settings::new().unwrap();
+        assert_eq!(
+            settings.allowed_bind_sources(),
+            &[
+                std::path::PathBuf::from("/srv/edgeAgent"),
+                std::path::PathBuf::from("/srv/edgeHub")
+            ]
+        );
+
+        unsafe {
+            std::env::set_var("AZIOT_EDGED_CONFIG", GOOD_SETTINGS_NO_ALLOWED_BINDS);
+        }
+        let settings = Settings::new().unwrap();
+        assert!(settings.allowed_bind_sources().is_empty());
     }
 
     #[test]

--- a/edgelet/edgelet-settings/test-files/sample_settings.allowed_binds.toml
+++ b/edgelet/edgelet-settings/test-files/sample_settings.allowed_binds.toml
@@ -1,0 +1,22 @@
+hostname = "localhost"
+homedir = "/tmp"
+allowed_bind_sources = ["/srv/edgeAgent", "/srv/edgeHub"]
+
+[agent]
+name = "edgeAgent"
+type = "docker"
+
+[agent.config]
+image = "microsoft/azureiotedge-agent:1.0"
+
+[connect]
+workload_uri = "http://localhost:8081"
+management_uri = "http://localhost:8080"
+
+[listen]
+workload_uri = "http://0.0.0.0:8081"
+management_uri = "http://0.0.0.0:8080"
+
+[moby_runtime]
+uri = "http://localhost:2375"
+network = "azure-iot-edge"

--- a/edgelet/edgelet-settings/test-files/sample_settings.no_allowed_binds.toml
+++ b/edgelet/edgelet-settings/test-files/sample_settings.no_allowed_binds.toml
@@ -1,0 +1,22 @@
+hostname = "localhost"
+homedir = "/tmp"
+allowed_bind_sources = []
+
+[agent]
+name = "edgeAgent"
+type = "docker"
+
+[agent.config]
+image = "microsoft/azureiotedge-agent:1.0"
+
+[connect]
+workload_uri = "http://localhost:8081"
+management_uri = "http://localhost:8080"
+
+[listen]
+workload_uri = "http://0.0.0.0:8081"
+management_uri = "http://0.0.0.0:8080"
+
+[moby_runtime]
+uri = "http://localhost:2375"
+network = "azure-iot-edge"

--- a/edgelet/edgelet-test-utils/src/settings.rs
+++ b/edgelet/edgelet-test-utils/src/settings.rs
@@ -56,6 +56,10 @@ impl edgelet_settings::RuntimeSettings for Settings {
         unimplemented!()
     }
 
+    fn allowed_bind_sources(&self) -> &[std::path::PathBuf] {
+        unimplemented!()
+    }
+
     fn iotedge_max_requests(&self) -> &edgelet_settings::IotedgeMaxRequests {
         unimplemented!()
     }

--- a/edgelet/iotedge/src/config/apply.rs
+++ b/edgelet/iotedge/src/config/apply.rs
@@ -215,6 +215,7 @@ async fn execute_inner(
     let super_config::Config {
         trust_bundle_cert,
         allow_elevated_docker_permissions,
+        allowed_bind_sources,
         auto_reprovisioning_mode,
         imported_master_encryption_key,
         additional_info,
@@ -548,6 +549,8 @@ async fn execute_inner(
             homedir: AZIOT_EDGED_HOMEDIR_PATH.into(),
 
             allow_elevated_docker_permissions: allow_elevated_docker_permissions.unwrap_or(true),
+
+            allowed_bind_sources: allowed_bind_sources.unwrap_or_default(),
 
             iotedge_max_requests,
 

--- a/edgelet/iotedge/src/config/import/mod.rs
+++ b/edgelet/iotedge/src/config/import/mod.rs
@@ -358,6 +358,7 @@ fn execute_inner(
 
     let config = super_config::Config {
         allow_elevated_docker_permissions: None,
+        allowed_bind_sources: None,
 
         trust_bundle_cert,
 

--- a/edgelet/iotedge/src/config/mp.rs
+++ b/edgelet/iotedge/src/config/mp.rs
@@ -34,6 +34,7 @@ To reconfigure IoT Edge, run:
 
     let config = super_config::Config {
         allow_elevated_docker_permissions: None,
+        allowed_bind_sources: None,
 
         trust_bundle_cert: None,
 

--- a/edgelet/iotedge/src/config/super_config.rs
+++ b/edgelet/iotedge/src/config/super_config.rs
@@ -15,6 +15,9 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_elevated_docker_permissions: Option<bool>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_bind_sources: Option<Vec<std::path::PathBuf>>,
+
     #[serde(default = "edgelet_settings::base::aziot::AutoReprovisioningMode::default")]
     pub auto_reprovisioning_mode: edgelet_settings::base::aziot::AutoReprovisioningMode,
 

--- a/edgelet/iotedge/test-files/config/ca-certs-est/edged.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs-est/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [agent]
 name = "edgeAgent"

--- a/edgelet/iotedge/test-files/config/ca-certs-est/super-config.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs-est/super-config.toml
@@ -1,5 +1,6 @@
 trust_bundle_cert = "file:///var/secrets/trusted-ca.pem"
 auto_reprovisioning_mode = "OnErrorOnly"
+allowed_bind_sources = []
 hostname = "my-device"
 
 [provisioning]

--- a/edgelet/iotedge/test-files/config/ca-certs-local-ca/edged.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs-local-ca/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [agent]
 name = "edgeAgent"

--- a/edgelet/iotedge/test-files/config/ca-certs/edged.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [agent]
 name = "edgeAgent"

--- a/edgelet/iotedge/test-files/config/ca-quickstart-custom/edged.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart-custom/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [agent]
 name = "edgeAgent"

--- a/edgelet/iotedge/test-files/config/ca-quickstart/edged.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/edged.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key-no-pad/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key-no-pad/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/dps-tpm/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/dps-x509/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/imported-master-encryption-key/edged.toml
+++ b/edgelet/iotedge/test-files/config/imported-master-encryption-key/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/edged.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/manual-connection-string-no-pad/edged.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-no-pad/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/manual-connection-string/edged.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/manual-x509/edged.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/moby-runtime-network-2/edged.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-network-2/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [agent]
 name = "edgeAgent"

--- a/edgelet/iotedge/test-files/config/moby-runtime-network/edged.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-network/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [agent]
 name = "edgeAgent"

--- a/edgelet/iotedge/test-files/config/nested-edge/edged.toml
+++ b/edgelet/iotedge/test-files/config/nested-edge/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/edged.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/edged.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/edged.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/edged.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/edged.toml
@@ -6,6 +6,7 @@ trust_bundle_cert = "aziot-edged-trust-bundle"
 auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
+allowed_bind_sources = []
 
 [edge_ca.auto_renew]
 rotate_key = true


### PR DESCRIPTION
## Summary

Add a top-level `allowed_bind_sources` setting that restricts module host bind mounts when `allow_elevated_docker_permissions` is `false`.

Configured entries are normalized and treated as path prefixes. IoT Edge continues to allow each module's workload socket and allows the management socket only for Edge Agent. Disallowed binds are removed with warnings so module creation follows the existing elevated-permission filtering behavior.

The filter covers `HostConfig.Binds`, structured bind mounts, `VolumesFrom`, bind-backed volume driver configurations, and alternate JSON field representations that Docker could otherwise interpret after filtering. Named and anonymous Docker volumes remain supported.

The code default is an empty allowlist. Linux TOML configuration suggests `/iotedge/storage` as an explicit storage prefix.

## Compatibility

Existing devices with `allow_elevated_docker_permissions = false` must list every required host bind source. Otherwise those binds are removed when modules are created.

Path checks are lexical and do not resolve symbolic links.

## Testing

- Added settings tests for omitted, custom, and explicitly empty allowlists.
- Added runtime tests for allowed prefixes, rejected paths, runtime sockets, structured mounts, inherited volumes, volume driver bypasses, and JSON field-name collisions.
- Updated config apply fixtures for the empty code default.
- Ran affected `docker`, `edgelet-settings`, `edgelet-docker`, and `iotedge` tests locally.
- Ran Clippy for affected production targets with warnings denied.
- Ran E2E validation on an Ubuntu VM with fixed edge installation and provided allow list.

## Azure IoT Edge PR checklist

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- [x] Description includes a concise summary of tests added or modified.
- [x] Description includes local testing performed.
