### PR TITLE
Remove privileged docker properties when allow_elevated = false

### DIFF
--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1072,7 +1072,7 @@ fn filter_privileged_properties(
 
     if remove_case_insensitive_keys(&mut create_options.other_properties, &DISALLOWED_PROPERTIES) {
         log::warn!(
-            "At least one of the following properties {DISALLOWED_PROPERTIES:?} is disallowed and was removed from the container create body. Set `allow_elevated_docker_permissions = true` in config.toml to allow usage of these properties."
+            "At least one of the following disallowed properties {DISALLOWED_PROPERTIES:?} was removed from the container create body. Set `allow_elevated_docker_permissions = true` in config.toml to allow usage of these properties."
         );
     }
 

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -357,7 +357,7 @@ where
         );
         let module_name = module.name().to_owned();
         let implicit_bind_sources = self.implicit_bind_sources(&module_name);
-        filter_bind_sources(
+        filter_privileged_properties(
             self.allow_elevated_docker_permissions,
             &self.allowed_bind_sources,
             &implicit_bind_sources,
@@ -1047,15 +1047,33 @@ fn has_volume_driver_config(properties: &BTreeMap<String, serde_json::Value>) ->
         })
 }
 
-fn filter_bind_sources(
+fn filter_privileged_properties(
     allow_elevated_docker_permissions: bool,
     allowed_bind_sources: &[PathBuf],
     implicit_bind_sources: &[PathBuf],
     module_name: &str,
     create_options: &mut ContainerCreateBody,
 ) {
+    // These properties specified in ContainerCreateBody's other_properties may allow elevation of container privilege.
+    // Drop them if allow_elevated_docker_permissions is not set.
+    const DISALLOWED_PROPERTIES: [&str; 7] = [
+        "Devices",
+        "PidMode",
+        "NetworkMode",
+        "IpcMode",
+        "SecurityOpt",
+        "UsernsMode",
+        "CgroupParent",
+    ];
+
     if allow_elevated_docker_permissions {
         return;
+    }
+
+    if remove_case_insensitive_keys(&mut create_options.other_properties, &DISALLOWED_PROPERTIES) {
+        log::warn!(
+            "At lease one of the following properties {DISALLOWED_PROPERTIES:?} is disallowed and was removed from the container create body. Set `allow_elevated_docker_permissions = true` in config.toml to allow usage of these properties."
+        );
     }
 
     if remove_case_insensitive_keys(&mut create_options.other_properties, &["HostConfig"]) {
@@ -1351,7 +1369,16 @@ mod tests {
     }
 
     #[test]
-    fn filter_bind_sources_does_nothing_when_elevated_permissions_are_allowed() {
+    fn filter_privileged_properties_does_nothing_when_elevated_permissions_are_allowed() {
+        let mut other_properties = BTreeMap::new();
+        other_properties.insert("Devices".into(), "/dev/sda".into());
+        other_properties.insert("PidMode".into(), "host".into());
+        other_properties.insert("NetworkMode".into(), "host".into());
+        other_properties.insert("IpcMode".into(), "host".into());
+        other_properties.insert("UsernsMode".into(), "host".into());
+        other_properties.insert("SecurityOpt".into(), "seccomp=unconfined".into());
+        other_properties.insert("CgroupParent".into(), "group".into());
+
         let mut create_options = ContainerCreateBody {
             host_config: Some(HostConfig {
                 binds: Some(vec!["/:/host".to_owned()]),
@@ -1363,18 +1390,30 @@ mod tests {
                 }]),
                 ..Default::default()
             }),
+            other_properties: other_properties.clone(),
             ..Default::default()
         };
 
-        filter_bind_sources(true, &[], &[], "module1", &mut create_options);
+        filter_privileged_properties(true, &[], &[], "module1", &mut create_options);
 
         let host_config = create_options.host_config.unwrap();
         assert_eq!(host_config.binds, Some(vec!["/:/host".to_owned()]));
         assert_eq!(host_config.mounts.unwrap().len(), 1);
+
+        assert_eq!(create_options.other_properties, other_properties);
     }
 
     #[test]
-    fn filter_bind_sources_uses_normalized_component_prefixes() {
+    fn filter_privileged_properties_uses_normalized_component_prefixes() {
+        let mut other_properties = BTreeMap::new();
+        other_properties.insert("Devices".into(), "/dev/sda".into());
+        other_properties.insert("PidMode".into(), "host".into());
+        other_properties.insert("NetworkMode".into(), "host".into());
+        other_properties.insert("IpcMode".into(), "host".into());
+        other_properties.insert("UsernsMode".into(), "host".into());
+        other_properties.insert("SecurityOpt".into(), "seccomp=unconfined".into());
+        other_properties.insert("CgroupParent".into(), "group".into());
+
         let mut create_options = ContainerCreateBody {
             host_config: Some(HostConfig {
                 binds: Some(vec![
@@ -1388,10 +1427,11 @@ mod tests {
                 ]),
                 ..Default::default()
             }),
+            other_properties,
             ..Default::default()
         };
 
-        filter_bind_sources(
+        filter_privileged_properties(
             false,
             &[PathBuf::from("/iotedge/storage")],
             &[],
@@ -1408,10 +1448,12 @@ mod tests {
                 "/anonymous".to_owned(),
             ])
         );
+
+        assert!(create_options.other_properties.is_empty());
     }
 
     #[test]
-    fn filter_bind_sources_filters_only_structured_bind_mounts() {
+    fn filter_privileged_properties_filters_only_structured_bind_mounts() {
         let mut create_options = ContainerCreateBody {
             host_config: Some(HostConfig {
                 mounts: Some(vec![
@@ -1466,7 +1508,7 @@ mod tests {
             ..Default::default()
         };
 
-        filter_bind_sources(
+        filter_privileged_properties(
             false,
             &[PathBuf::from("/iotedge/storage")],
             &[],
@@ -1485,7 +1527,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_bind_sources_removes_inherited_volumes() {
+    fn filter_privileged_properties_removes_inherited_volumes() {
         let mut create_options = ContainerCreateBody {
             host_config: Some(HostConfig {
                 volumes_from: Some(vec!["other-container".to_owned()]),
@@ -1494,13 +1536,13 @@ mod tests {
             ..Default::default()
         };
 
-        filter_bind_sources(false, &[], &[], "module1", &mut create_options);
+        filter_privileged_properties(false, &[], &[], "module1", &mut create_options);
 
         assert_eq!(create_options.host_config.unwrap().volumes_from, None);
     }
 
     #[test]
-    fn filter_bind_sources_removes_case_insensitive_field_collisions() {
+    fn filter_privileged_properties_removes_case_insensitive_field_collisions() {
         let mut create_options = ContainerCreateBody {
             host_config: Some(HostConfig {
                 mounts: Some(vec![
@@ -1553,7 +1595,7 @@ mod tests {
             ..Default::default()
         };
 
-        filter_bind_sources(
+        filter_privileged_properties(
             false,
             &[PathBuf::from("/iotedge/storage")],
             &[],
@@ -1568,7 +1610,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_bind_sources_preserves_required_runtime_sockets() {
+    fn filter_privileged_properties_preserves_required_runtime_sockets() {
         let mut create_options = ContainerCreateBody {
             host_config: Some(HostConfig {
                 binds: Some(vec![
@@ -1581,7 +1623,7 @@ mod tests {
             ..Default::default()
         };
 
-        filter_bind_sources(
+        filter_privileged_properties(
             false,
             &[],
             &[
@@ -1608,7 +1650,7 @@ mod tests {
             "/var/lib/aziot/edged/mnt/module1.sock:/var/run/iotedge/workload.sock".to_owned(),
             "/var/run/iotedge/mgmt.sock:/var/run/iotedge/mgmt.sock".to_owned(),
         ]);
-        filter_bind_sources(
+        filter_privileged_properties(
             false,
             &[],
             &[PathBuf::from("/var/lib/aziot/edged/mnt/module1.sock")],

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1404,7 +1404,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_privileged_properties_uses_normalized_component_prefixes() {
+    fn filter_privileged_properties_removes_disallowed_properties() {
         let mut other_properties = BTreeMap::new();
         other_properties.insert("Devices".into(), "/dev/sda".into());
         other_properties.insert("PidMode".into(), "host".into());
@@ -1415,6 +1415,32 @@ mod tests {
         other_properties.insert("CgroupParent".into(), "group".into());
         other_properties.insert("OtherProp".into(), "test".into());
 
+        let mut create_options = ContainerCreateBody {
+            host_config: Some(HostConfig {
+                binds: Some(vec!["/:/host".to_owned()]),
+                mounts: Some(vec![Mount {
+                    source: Some("/var/run/docker.sock".to_owned()),
+                    target: Some("/var/run/docker.sock".to_owned()),
+                    r#type: Some("bind".to_owned()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            other_properties,
+            ..Default::default()
+        };
+
+        filter_privileged_properties(false, &[], &[], "module1", &mut create_options);
+
+        assert_eq!(1, create_options.other_properties.len());
+        assert_eq!(
+            "test",
+            create_options.other_properties.remove("OtherProp").unwrap()
+        );
+    }
+
+    #[test]
+    fn filter_privileged_properties_uses_normalized_component_prefixes() {
         let mut create_options = ContainerCreateBody {
             host_config: Some(HostConfig {
                 binds: Some(vec![
@@ -1428,7 +1454,6 @@ mod tests {
                 ]),
                 ..Default::default()
             }),
-            other_properties,
             ..Default::default()
         };
 
@@ -1449,9 +1474,6 @@ mod tests {
                 "/anonymous".to_owned(),
             ])
         );
-
-        assert_eq!(1, create_options.other_properties.len());
-        assert_eq!("test", create_options.other_properties.remove("OtherProp").unwrap());
     }
 
     #[test]

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1413,6 +1413,7 @@ mod tests {
         other_properties.insert("UsernsMode".into(), "host".into());
         other_properties.insert("SecurityOpt".into(), "seccomp=unconfined".into());
         other_properties.insert("CgroupParent".into(), "group".into());
+        other_properties.insert("OtherProp".into(), "test".into());
 
         let mut create_options = ContainerCreateBody {
             host_config: Some(HostConfig {
@@ -1449,7 +1450,8 @@ mod tests {
             ])
         );
 
-        assert!(create_options.other_properties.is_empty());
+        assert_eq!(1, create_options.other_properties.len());
+        assert_eq!("test", create_options.other_properties.remove("OtherProp").unwrap());
     }
 
     #[test]

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1072,7 +1072,7 @@ fn filter_privileged_properties(
 
     if remove_case_insensitive_keys(&mut create_options.other_properties, &DISALLOWED_PROPERTIES) {
         log::warn!(
-            "At lease one of the following properties {DISALLOWED_PROPERTIES:?} is disallowed and was removed from the container create body. Set `allow_elevated_docker_permissions = true` in config.toml to allow usage of these properties."
+            "At least one of the following properties {DISALLOWED_PROPERTIES:?} is disallowed and was removed from the container create body. Set `allow_elevated_docker_permissions = true` in config.toml to allow usage of these properties."
         );
     }
 


### PR DESCRIPTION
Renames `filter_bind_sources` to `filter_privileged_properties` and expands it to remove the following properties if specified when `allow_elevated_docker_permissions = false`: "Devices", "PidMode", "NetworkMode", "IpcMode", "SecurityOpt", "UsernsMode", "CgroupParent".

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.
